### PR TITLE
[2.1.1] Various fixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ configurations.all {
 }
 
 group = "com.thevoxelbox"
-version = "2.1.1-SNAPSHOT"
+version = "2.1.2-SNAPSHOT"
 
 bukkit {
 	name = "FastAsyncVoxelSniper"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ configurations.all {
 }
 
 group = "com.thevoxelbox"
-version = "2.1.2-SNAPSHOT"
+version = "2.1.1"
 
 bukkit {
 	name = "FastAsyncVoxelSniper"

--- a/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperPlugin.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperPlugin.java
@@ -36,6 +36,7 @@ public class VoxelSniperPlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        plugin = this;
         this.voxelSniperConfig = loadConfig();
         this.brushRegistry = loadBrushRegistry();
         this.performerRegistry = loadPerformerRegistry();

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/AbstractBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/AbstractBrush.java
@@ -166,11 +166,7 @@ public abstract class AbstractBrush implements Brush {
     }
 
     public void setBlockType(int x, int y, int z, BlockType type) {
-        try {
-            editSession.setBlock(x, y, z, type.getDefaultState());
-        } catch (WorldEditException e) {
-            throw new RuntimeException(e);
-        }
+        setBlockData(x, y, z, type.getDefaultState());
     }
 
     public void setBlockData(BlockVector3 position, BlockState blockState) {
@@ -183,6 +179,9 @@ public abstract class AbstractBrush implements Brush {
     public void setBlockData(int x, int y, int z, BlockState blockState) {
         try {
             editSession.setBlock(x, y, z, blockState);
+            if (blockState.getMaterial().isTile()) {
+                editSession.setTile(x, y, z, blockState.getMaterial().getDefaultTile());
+            }
         } catch (WorldEditException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/CopyPastaBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/CopyPastaBrush.java
@@ -29,7 +29,7 @@ public class CopyPastaBrush extends AbstractBrush {
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
-        String parameter = parameters[0];
+        String parameter = parameters[1];
         if (parameter.equalsIgnoreCase("info")) {
             snipe.createMessageSender()
                     .message(ChatColor.GOLD + "CopyPasta Parameters:")

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/PullBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/PullBrush.java
@@ -23,7 +23,7 @@ public class PullBrush extends AbstractBrush {
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
-        Double pinch = NumericParser.parseDouble(parameters[0]);
+        Double pinch = NumericParser.parseDouble(parameters[1]);
         Double bubble = NumericParser.parseDouble(parameters[1]);
         if (pinch == null || bubble == null) {
             SnipeMessenger messenger = snipe.createMessenger();

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/SnowConeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/SnowConeBrush.java
@@ -14,7 +14,7 @@ public class SnowConeBrush extends AbstractBrush {
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
-        String firstParameter = parameters[0];
+        String firstParameter = parameters[1];
         if (firstParameter.equalsIgnoreCase("info")) {
             SnipeMessenger messenger = snipe.createMessenger();
             messenger.sendMessage(ChatColor.GOLD + "Snow Cone Parameters:");

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/SpiralStaircaseBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/SpiralStaircaseBrush.java
@@ -23,7 +23,7 @@ public class SpiralStaircaseBrush extends AbstractBrush {
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
-        if (parameters[0].equalsIgnoreCase("info")) {
+        if (parameters[1].equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.GOLD + "Spiral Staircase Parameters:");
             messenger.sendMessage(ChatColor.AQUA + "/b sstair 'block' (default) | 'step' | 'woodstair' | 'cobblestair' -- set the type of staircase");
             messenger.sendMessage(ChatColor.AQUA + "/b sstair 'c' (default) | 'cc' -- set the turning direction of staircase");

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/blend/BlendBallBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/blend/BlendBallBrush.java
@@ -19,7 +19,7 @@ public class BlendBallBrush extends AbstractBlendBrush {
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
-        if (parameters[0].equalsIgnoreCase("info")) {
+        if (parameters[1].equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.GOLD + "Blend Ball Parameters:");
             messenger.sendMessage(ChatColor.AQUA + "/b bb water -- toggle include or exclude (default: exclude) water");
             return;

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/blend/BlendDiscBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/blend/BlendDiscBrush.java
@@ -19,7 +19,7 @@ public class BlendDiscBrush extends AbstractBlendBrush {
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
-        if (parameters[0].equalsIgnoreCase("info")) {
+        if (parameters[1].equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.GOLD + "Blend Disc Parameters:");
             messenger.sendMessage(ChatColor.AQUA + "/b bd water -- toggle include or exclude (default) water");
             return;

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/blend/BlendVoxelBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/blend/BlendVoxelBrush.java
@@ -19,7 +19,7 @@ public class BlendVoxelBrush extends AbstractBlendBrush {
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
-        if (parameters[0].equalsIgnoreCase("info")) {
+        if (parameters[1].equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.GOLD + "Blend Voxel Parameters:");
             messenger.sendMessage(ChatColor.AQUA + "/b bv water -- toggle include or exclude (default) water");
             return;

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/blend/BlendVoxelDiscBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/blend/BlendVoxelDiscBrush.java
@@ -19,7 +19,7 @@ public class BlendVoxelDiscBrush extends AbstractBlendBrush {
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
-        if (parameters[0].equalsIgnoreCase("info")) {
+        if (parameters[1].equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.GOLD + "Blend Voxel Disc Parameters:");
             messenger.sendMessage(ChatColor.AQUA + "/b bvd water -- toggle include or exclude (default) water");
             return;

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/canyon/CanyonBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/canyon/CanyonBrush.java
@@ -18,7 +18,7 @@ public class CanyonBrush extends AbstractBrush {
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
-        String firstParameter = parameters[0];
+        String firstParameter = parameters[1];
         if (firstParameter.equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.GREEN + "y[number] to set the Level to which the land will be shifted down");
         }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityBrush.java
@@ -24,7 +24,7 @@ public class EntityBrush extends AbstractBrush {
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
-        if (parameters[0].equalsIgnoreCase("info")) {
+        if (parameters[1].equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.BLUE + "The available entity types are as follows:");
             String names = Arrays.stream(EntityType.values())
                     .map(currentEntity -> ChatColor.AQUA + " | " + ChatColor.DARK_GREEN + currentEntity.getName())

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/LineBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/LineBrush.java
@@ -22,7 +22,7 @@ public class LineBrush extends AbstractPerformerBrush {
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
-        if (parameters[0].equalsIgnoreCase("info")) {
+        if (parameters[1].equalsIgnoreCase("info")) {
             SnipeMessenger messenger = snipe.createMessenger();
             messenger.sendMessage(ChatColor.GOLD + "Line Brush instructions: Right click first point with the arrow. Right click with powder to draw a line to set the second point.");
         }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/ThreePointCircleBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/ThreePointCircleBrush.java
@@ -26,7 +26,7 @@ public class ThreePointCircleBrush extends AbstractPerformerBrush {
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
-        if (parameters[0].equalsIgnoreCase("info")) {
+        if (parameters[1].equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.YELLOW + "3-Point Circle Brush instructions: Select three corners with the arrow brush, then generate the Circle with the powder brush.");
             String toleranceOptions = Arrays.stream(Tolerance.values())
                     .map(tolerance -> tolerance.name()

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/TriangleBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/TriangleBrush.java
@@ -23,7 +23,7 @@ public class TriangleBrush extends AbstractPerformerBrush {
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
-        if (parameters[0].equalsIgnoreCase("info")) {
+        if (parameters[1].equalsIgnoreCase("info")) {
             SnipeMessenger messenger = snipe.createMessenger();
             messenger.sendMessage(ChatColor.GOLD + "Triangle Brush instructions: Select three corners with the arrow brush, then generate the triangle with the powder brush.");
         }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DBrush.java
@@ -20,7 +20,7 @@ public class Rotation2DBrush extends AbstractBrush {
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
-        this.angle = Math.toRadians(Double.parseDouble(parameters[0]));
+        this.angle = Math.toRadians(Double.parseDouble(parameters[1]));
         SnipeMessenger messenger = snipe.createMessenger();
         messenger.sendMessage(ChatColor.GREEN + "Angle set to " + this.angle);
     }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DVerticalBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DVerticalBrush.java
@@ -24,9 +24,9 @@ public class Rotation2DVerticalBrush extends AbstractBrush {
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
-        Double angle = NumericParser.parseDouble(parameters[0]);
+        Double angle = NumericParser.parseDouble(parameters[1]);
         if (angle == null) {
-            messenger.sendMessage("Exception while parsing parameter: " + parameters[0]);
+            messenger.sendMessage("Exception while parsing parameter: " + parameters[1]);
             return;
         }
         this.angle = Math.toRadians(angle);

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/shell/ShellVoxelBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/shell/ShellVoxelBrush.java
@@ -13,7 +13,7 @@ public class ShellVoxelBrush extends AbstractBrush {
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
-        if (parameters[0].equalsIgnoreCase("info")) {
+        if (parameters[1].equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.GOLD + "Shell Voxel Parameters:");
         } else {
             messenger.sendMessage(ChatColor.RED + "Invalid parameter - see the info message for help.");

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stamp/CloneStampBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stamp/CloneStampBrush.java
@@ -17,7 +17,7 @@ public class CloneStampBrush extends AbstractStampBrush {
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
         ToolkitProperties toolkitProperties = snipe.getToolkitProperties();
-        String parameter = parameters[0];
+        String parameter = parameters[1];
         if (parameter.equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.GOLD + "Clone / Stamp Cylinder brush parameters");
             messenger.sendMessage(ChatColor.GREEN + "cs f -- Activates Fill mode");

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilBrush.java
@@ -44,13 +44,13 @@ public class StencilBrush extends AbstractBrush {
     private short xRef;
     private short zRef;
     private short yRef;
-    private byte pasteParam;
     private byte point = 1;
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
-        String firstParameter = parameters[0];
+        String firstParameter = parameters[1];
+        byte pasteParam;
         if (firstParameter.equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.GOLD + "Stencil brush Parameters:");
             messenger.sendMessage(ChatColor.AQUA + "/b schem [optional: 'full' 'fill' or 'replace', with fill as default] [name] -- Loads the specified schematic.  Allowed size of schematic is based on rank.  Full/fill/replace must come first.  Full = paste all blocks, fill = paste only into air blocks, replace = paste full blocks in only, but replace anything in their way.");
@@ -58,16 +58,20 @@ public class StencilBrush extends AbstractBrush {
             return;
         } else if (firstParameter.equalsIgnoreCase("full")) {
             this.pasteOption = 0;
-            this.pasteParam = 1;
+            pasteParam = 1;
         } else if (firstParameter.equalsIgnoreCase("fill")) {
             this.pasteOption = 1;
-            this.pasteParam = 1;
+            pasteParam = 1;
         } else if (firstParameter.equalsIgnoreCase("replace")) {
             this.pasteOption = 2;
-            this.pasteParam = 1;
+            pasteParam = 1;
+        } else {
+            // Reset to [name] parameter expected.
+            this.pasteOption = 1;
+            pasteParam = 0;
         }
         try {
-            this.filename = parameters[1 + this.pasteParam];
+            this.filename = parameters[1 + pasteParam];
             File file = new File(VoxelSniperPlugin.getPlugin().getDataFolder() + "/stencils/" + this.filename + ".vstencil");
             if (file.exists()) {
                 messenger.sendMessage(ChatColor.RED + "Stencil '" + this.filename + "' exists and was loaded. Make sure you are using powder if you do not want any chance of overwriting the file.");
@@ -75,6 +79,7 @@ public class StencilBrush extends AbstractBrush {
                 messenger.sendMessage(ChatColor.AQUA + "Stencil '" + this.filename + "' does not exist. Ready to be saved to, but cannot be pasted.");
             }
         } catch (RuntimeException exception) {
+            exception.printStackTrace();
             messenger.sendMessage(ChatColor.RED + "You need to type a stencil name.");
         }
     }
@@ -122,7 +127,7 @@ public class StencilBrush extends AbstractBrush {
     private void stencilPaste(Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
         if (this.filename.matches("NoFileLoaded")) {
-            messenger.sendMessage(ChatColor.RED + "You did not specify a filename.  This is required.");
+            messenger.sendMessage(ChatColor.RED + "You did not specify a filename. This is required.");
             return;
         }
         File file = new File(VoxelSniperPlugin.getPlugin().getDataFolder() + "/stencils/" + this.filename + ".vstencil");

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilListBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilListBrush.java
@@ -37,7 +37,7 @@ public class StencilListBrush extends AbstractBrush {
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
-        String secondParameter = parameters[0];
+        String secondParameter = parameters[1];
         if (secondParameter.equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.GOLD + "Stencil List brush Parameters:");
             messenger.sendMessage(ChatColor.AQUA + "/b schem [optional: 'full' 'fill' or 'replace', with fill as default] [name] -- Loads the specified stencil list.  Full/fill/replace must come first.  Full = paste all blocks, fill = paste only into air blocks, replace = paste full blocks in only, but replace anything in their way.");

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/AbstractPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/AbstractPerformer.java
@@ -9,16 +9,15 @@ import com.thevoxelbox.voxelsniper.performer.Performer;
 public abstract class AbstractPerformer implements Performer {
 
     public void setBlockType(EditSession editSession, int x, int y, int z, BlockType type) {
-        try {
-            editSession.setBlock(x, y, z, type.getDefaultState());
-        } catch (WorldEditException e) {
-            throw new RuntimeException(e);
-        }
+        setBlockData(editSession, x, y, z, type.getDefaultState());
     }
 
     public void setBlockData(EditSession editSession, int x, int y, int z, BlockState blockState) {
         try {
             editSession.setBlock(x, y, z, blockState);
+            if (blockState.getMaterial().isTile()) {
+                editSession.setTile(x, y, z, blockState.getMaterial().getDefaultTile());
+            }
         } catch (WorldEditException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
- Fixes stencil command (plugin instance was not intitialized, caused issues getting data folder...)
- Fixes some other command params handling, since the firstParameter is actually at index ``1``. _The first one, ``0``, refers to the brush sub-command or an empty string._

- Fixes invisible tile entities placed with FAVS by initializing their CompoundTag if needed.

- Bump version.