### PR TITLE
Improvements

### DIFF
--- a/src/main/java/com/thevoxelbox/voxelsniper/BrushRegistrar.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/BrushRegistrar.java
@@ -841,7 +841,7 @@ public class BrushRegistrar {
                 .alias("sio")
                 .alias("signoverwriter")
                 .alias("sign_overwrite")
-                .creator(() -> new SignOverwriteBrush(this.pluginDataFolder))
+                .creator(() -> new SignOverwriteBrush())
                 .build();
         this.registry.register(properties);
     }

--- a/src/main/java/com/thevoxelbox/voxelsniper/CommandRegistrar.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/CommandRegistrar.java
@@ -17,6 +17,7 @@ import com.thevoxelbox.voxelsniper.command.executor.VoxelListExecutor;
 import com.thevoxelbox.voxelsniper.command.executor.VoxelReplaceExecutor;
 import com.thevoxelbox.voxelsniper.command.executor.VoxelSniperExecutor;
 import com.thevoxelbox.voxelsniper.command.property.CommandProperties;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 public class CommandRegistrar {
@@ -224,7 +225,7 @@ public class CommandRegistrar {
                 .alias("vs")
                 .usage("/vs")
                 .usage("Example: /vs -- Returns the current brush settings.")
-                .sender(Player.class)
+                .sender(CommandSender.class)
                 .build();
         VoxelSniperExecutor executor = new VoxelSniperExecutor(this.plugin);
         this.registry.register(properties, executor);

--- a/src/main/java/com/thevoxelbox/voxelsniper/FastAsyncVoxelSniper.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/FastAsyncVoxelSniper.java
@@ -19,7 +19,6 @@ public class FastAsyncVoxelSniper {
     }
 
     public void initFavs() {
-
         setupCommand("/p", (sender, command, label, args) -> {
             if (sender instanceof Player && sender.hasPermission("voxelsniper.sniper")) {
                 @Nullable PluginCommand cmd = plugin.getCommand("p");

--- a/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperPlugin.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperPlugin.java
@@ -2,6 +2,7 @@ package com.thevoxelbox.voxelsniper;
 
 import com.thevoxelbox.voxelsniper.brush.Brush;
 import com.thevoxelbox.voxelsniper.brush.BrushRegistry;
+import com.thevoxelbox.voxelsniper.brush.property.BrushProperties;
 import com.thevoxelbox.voxelsniper.command.CommandRegistry;
 import com.thevoxelbox.voxelsniper.config.VoxelSniperConfig;
 import com.thevoxelbox.voxelsniper.config.VoxelSniperConfigLoader;
@@ -9,6 +10,7 @@ import com.thevoxelbox.voxelsniper.listener.PlayerInteractListener;
 import com.thevoxelbox.voxelsniper.listener.PlayerJoinListener;
 import com.thevoxelbox.voxelsniper.performer.Performer;
 import com.thevoxelbox.voxelsniper.performer.PerformerRegistry;
+import com.thevoxelbox.voxelsniper.performer.property.PerformerProperties;
 import com.thevoxelbox.voxelsniper.sniper.SniperRegistry;
 import io.papermc.lib.PaperLib;
 import org.bstats.bukkit.Metrics;
@@ -105,12 +107,14 @@ public class VoxelSniperPlugin extends JavaPlugin {
 
     private void testRegistries() {
         // Load brushes and performers to ensure their configuration is up-to-date.
-        this.brushRegistry.getBrushesProperties().forEach((key, properties) -> {
+        this.brushRegistry.getBrushesProperties().keySet().stream().sorted().forEachOrdered(key -> {
+            BrushProperties properties = this.brushRegistry.getBrushProperties(key);
             Brush brush = properties.getCreator().create();
             brush.setProperties(properties);
             brush.loadProperties();
         });
-        this.performerRegistry.getPerformerProperties().forEach((key, properties) -> {
+        this.performerRegistry.getPerformerProperties().keySet().stream().sorted().forEachOrdered(key -> {
+            PerformerProperties properties = this.performerRegistry.getPerformerProperties(key);
             Performer performer = properties.getCreator().create();
             performer.setProperties(properties);
             performer.loadProperties();

--- a/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperPlugin.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperPlugin.java
@@ -1,11 +1,13 @@
 package com.thevoxelbox.voxelsniper;
 
+import com.thevoxelbox.voxelsniper.brush.Brush;
 import com.thevoxelbox.voxelsniper.brush.BrushRegistry;
 import com.thevoxelbox.voxelsniper.command.CommandRegistry;
 import com.thevoxelbox.voxelsniper.config.VoxelSniperConfig;
 import com.thevoxelbox.voxelsniper.config.VoxelSniperConfigLoader;
 import com.thevoxelbox.voxelsniper.listener.PlayerInteractListener;
 import com.thevoxelbox.voxelsniper.listener.PlayerJoinListener;
+import com.thevoxelbox.voxelsniper.performer.Performer;
 import com.thevoxelbox.voxelsniper.performer.PerformerRegistry;
 import com.thevoxelbox.voxelsniper.sniper.SniperRegistry;
 import io.papermc.lib.PaperLib;
@@ -21,10 +23,10 @@ import java.io.File;
 public class VoxelSniperPlugin extends JavaPlugin {
 
     public static VoxelSniperPlugin plugin;
-    private VoxelSniperConfig voxelSniperConfig;
     private BrushRegistry brushRegistry;
     private PerformerRegistry performerRegistry;
     private SniperRegistry sniperRegistry;
+    private VoxelSniperConfig voxelSniperConfig;
 
     public static JavaPlugin getPlugin() {
         return plugin;
@@ -37,6 +39,7 @@ public class VoxelSniperPlugin extends JavaPlugin {
         this.brushRegistry = loadBrushRegistry();
         this.performerRegistry = loadPerformerRegistry();
         this.sniperRegistry = new SniperRegistry();
+        testRegistries();
         loadCommands();
         loadListeners();
         new FastAsyncVoxelSniper(this);
@@ -62,7 +65,8 @@ public class VoxelSniperPlugin extends JavaPlugin {
                 voxelSniperConfigLoader.getLitesniperRestrictedMaterials(),
                 voxelSniperConfigLoader.getBrushSizeWarningThreshold(),
                 voxelSniperConfigLoader.getDefaultVoxelHeight(),
-                voxelSniperConfigLoader.getDefaultCylinderCenter()
+                voxelSniperConfigLoader.getDefaultCylinderCenter(),
+                voxelSniperConfigLoader.getBrushProperties()
         );
     }
 
@@ -96,6 +100,21 @@ public class VoxelSniperPlugin extends JavaPlugin {
     public void reload() {
         this.reloadConfig();
         this.voxelSniperConfig = loadConfig();
+        testRegistries();
+    }
+
+    private void testRegistries() {
+        // Load brushes and performers to ensure their configuration is up-to-date.
+        this.brushRegistry.getBrushesProperties().forEach((key, properties) -> {
+            Brush brush = properties.getCreator().create();
+            brush.setProperties(properties);
+            brush.loadProperties();
+        });
+        this.performerRegistry.getPerformerProperties().forEach((key, properties) -> {
+            Performer performer = properties.getCreator().create();
+            performer.setProperties(properties);
+            performer.loadProperties();
+        });
     }
 
     public VoxelSniperConfig getVoxelSniperConfig() {

--- a/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperPlugin.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperPlugin.java
@@ -56,7 +56,7 @@ public class VoxelSniperPlugin extends JavaPlugin {
     private VoxelSniperConfig loadConfig() {
         saveDefaultConfig();
         FileConfiguration config = getConfig();
-        VoxelSniperConfigLoader voxelSniperConfigLoader = new VoxelSniperConfigLoader(config);
+        VoxelSniperConfigLoader voxelSniperConfigLoader = new VoxelSniperConfigLoader(this, config);
 
         return new VoxelSniperConfig(
                 voxelSniperConfigLoader.isMessageOnLoginEnabled(),

--- a/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperPlugin.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperPlugin.java
@@ -1,7 +1,5 @@
 package com.thevoxelbox.voxelsniper;
 
-import com.sk89q.worldedit.world.block.BlockType;
-import com.sk89q.worldedit.world.block.BlockTypes;
 import com.thevoxelbox.voxelsniper.brush.BrushRegistry;
 import com.thevoxelbox.voxelsniper.command.CommandRegistry;
 import com.thevoxelbox.voxelsniper.config.VoxelSniperConfig;
@@ -19,10 +17,6 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.incendo.serverlib.ServerLib;
 
 import java.io.File;
-import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 public class VoxelSniperPlugin extends JavaPlugin {
 
@@ -58,15 +52,18 @@ public class VoxelSniperPlugin extends JavaPlugin {
         saveDefaultConfig();
         FileConfiguration config = getConfig();
         VoxelSniperConfigLoader voxelSniperConfigLoader = new VoxelSniperConfigLoader(config);
-        boolean messageOnLoginEnabled = voxelSniperConfigLoader.isMessageOnLoginEnabled();
-        int litesniperMaxBrushSize = voxelSniperConfigLoader.getLitesniperMaxBrushSize();
-        List<BlockType> litesniperRestrictedMaterials = voxelSniperConfigLoader.getLitesniperRestrictedMaterials()
-                .stream()
-                .map(key -> key.toLowerCase(Locale.ROOT))
-                .map(BlockTypes::get)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
-        return new VoxelSniperConfig(messageOnLoginEnabled, litesniperMaxBrushSize, litesniperRestrictedMaterials);
+
+        return new VoxelSniperConfig(
+                voxelSniperConfigLoader.isMessageOnLoginEnabled(),
+                voxelSniperConfigLoader.getDefaultBlockMaterial(),
+                voxelSniperConfigLoader.getDefaultReplaceBlockMaterial(),
+                voxelSniperConfigLoader.getDefaultBrushSize(),
+                voxelSniperConfigLoader.getLitesniperMaxBrushSize(),
+                voxelSniperConfigLoader.getLitesniperRestrictedMaterials(),
+                voxelSniperConfigLoader.getBrushSizeWarningThreshold(),
+                voxelSniperConfigLoader.getDefaultVoxelHeight(),
+                voxelSniperConfigLoader.getDefaultCylinderCenter()
+        );
     }
 
     private BrushRegistry loadBrushRegistry() {
@@ -94,6 +91,11 @@ public class VoxelSniperPlugin extends JavaPlugin {
         PluginManager pluginManager = Bukkit.getPluginManager();
         pluginManager.registerEvents(new PlayerJoinListener(this), this);
         pluginManager.registerEvents(new PlayerInteractListener(this), this);
+    }
+
+    public void reload() {
+        this.reloadConfig();
+        this.voxelSniperConfig = loadConfig();
     }
 
     public VoxelSniperConfig getVoxelSniperConfig() {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/Brush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/Brush.java
@@ -2,6 +2,7 @@ package com.thevoxelbox.voxelsniper.brush;
 
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.thevoxelbox.voxelsniper.brush.property.BrushProperties;
 import com.thevoxelbox.voxelsniper.sniper.snipe.Snipe;
 import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolAction;
 
@@ -56,5 +57,24 @@ public interface Brush {
      * @param snipe Snipe
      */
     void sendInfo(Snipe snipe);
+
+    /**
+     * Return brush properties.
+     *
+     * @return brush properties
+     */
+    BrushProperties getProperties();
+
+    /**
+     * Set brush properties.
+     *
+     * @param properties brush properties
+     */
+    void setProperties(BrushProperties properties);
+
+    /**
+     * Load brush properties.
+     */
+    void loadProperties();
 
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/AbstractBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/AbstractBrush.java
@@ -312,8 +312,8 @@ public abstract class AbstractBrush implements Brush {
      *
      * @param propertyName       the name of the property
      * @param defaultValue       the default value to set and return
-     * @param defaultConfigValue the default config value to set, objets such as Enum and Registry values are not serializable*
-     * @return the associated proprorty, or the default value
+     * @param defaultConfigValue the default config value to set, objets such as Enum and Registry values are not serializable
+     * @return the associated property, or the default value
      */
     public Object getProperty(String propertyName, Object defaultValue, Object defaultConfigValue) {
         String brush = this.properties.getName();

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/AbstractBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/AbstractBrush.java
@@ -94,10 +94,11 @@ public abstract class AbstractBrush implements Brush {
 
     public int clampY(int y) {
         int clampedY = y;
-        if (clampedY < 0) {
-            clampedY = 0;
+        int minHeight = editSession.getMinY();
+        if (clampedY <= minHeight) {
+            clampedY = minHeight;
         } else {
-            int maxHeight = editSession.getMaxY() + 1;
+            int maxHeight = editSession.getMaxY();
             if (clampedY > maxHeight) {
                 clampedY = maxHeight;
             }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/AbstractBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/AbstractBrush.java
@@ -28,6 +28,8 @@ import org.bukkit.ChatColor;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 
+import java.io.File;
+import java.text.DecimalFormat;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -37,10 +39,12 @@ import java.util.stream.Stream;
 
 public abstract class AbstractBrush implements Brush {
 
-    protected static final VoxelSniperPlugin plugin = VoxelSniperPlugin.plugin;
-    protected static final VoxelSniperConfig config = plugin.getVoxelSniperConfig();
+    protected static final VoxelSniperPlugin PLUGIN = VoxelSniperPlugin.plugin;
+    protected static final VoxelSniperConfig CONFIG = PLUGIN.getVoxelSniperConfig();
+    protected static final File PLUGIN_DATA_FOLDER = PLUGIN.getDataFolder();
 
     protected static final int CHUNK_SIZE = 16;
+    protected static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat(".##");
 
     private BrushProperties properties;
 
@@ -72,7 +76,7 @@ public abstract class AbstractBrush implements Brush {
      * @param index       Parameter index
      * @return Sorted completions.
      */
-    protected List<String> sortCompletions(Stream<String> completions, String parameter, int index) {
+    public List<String> sortCompletions(Stream<String> completions, String parameter, int index) {
         // The first brush parameter may be info.
         // Removing MINECRAFT_IDENTIFIER permits completing whether minecraft:XXXX or XXXX.
         String parameterLowered = (parameter.startsWith(Identifiers.MINECRAFT_IDENTIFIER)
@@ -313,11 +317,11 @@ public abstract class AbstractBrush implements Brush {
      */
     protected Object getProperty(String propertyName, Object defaultValue, Object defaultConfigValue) {
         String brush = this.properties.getName();
-        Object currentPropertyValue = config.getBrushProperties()
+        Object currentPropertyValue = CONFIG.getBrushProperties()
                 .computeIfAbsent(brush, brushName -> new HashMap<>())
                 .putIfAbsent(propertyName, defaultValue);
         if (currentPropertyValue == null) {
-            config.saveBrushPropertyToConfig(brush, propertyName, defaultConfigValue);
+            CONFIG.saveBrushPropertyToConfig(brush, propertyName, defaultConfigValue);
         }
         return currentPropertyValue;
     }
@@ -329,7 +333,7 @@ public abstract class AbstractBrush implements Brush {
             return (String) propertyValue;
         }
 
-        plugin.getLogger().warning("Invalid or missing String property '" + propertyName + "' value for '" +
+        PLUGIN.getLogger().warning("Invalid or missing String property '" + propertyName + "' value for '" +
                 this.properties.getName() + "' brush! Setting up the default one...");
         return defaultValue;
     }
@@ -341,7 +345,7 @@ public abstract class AbstractBrush implements Brush {
             return (boolean) propertyValue;
         }
 
-        plugin.getLogger().warning("Invalid or missing Boolean property '" + propertyName + "' value for '" +
+        PLUGIN.getLogger().warning("Invalid or missing Boolean property '" + propertyName + "' value for '" +
                 this.properties.getName() + "' brush! Setting up the default one...");
         return defaultValue;
     }
@@ -353,7 +357,7 @@ public abstract class AbstractBrush implements Brush {
             return (int) propertyValue;
         }
 
-        plugin.getLogger().warning("Invalid or missing Integer property '" + propertyName + "' value for '" +
+        PLUGIN.getLogger().warning("Invalid or missing Integer property '" + propertyName + "' value for '" +
                 this.properties.getName() + "' brush! Setting up the default one...");
         return defaultValue;
     }
@@ -365,7 +369,7 @@ public abstract class AbstractBrush implements Brush {
             return (double) propertyValue;
         }
 
-        plugin.getLogger().warning("Invalid or missing Double property '" + propertyName + "' value for '" +
+        PLUGIN.getLogger().warning("Invalid or missing Double property '" + propertyName + "' value for '" +
                 this.properties.getName() + "' brush! Setting up the default one...");
         return defaultValue;
     }
@@ -377,7 +381,7 @@ public abstract class AbstractBrush implements Brush {
             return (List<?>) propertyValue;
         }
 
-        plugin.getLogger().warning("Invalid or missing List property '" + propertyName + "' value for '" +
+        PLUGIN.getLogger().warning("Invalid or missing List property '" + propertyName + "' value for '" +
                 this.properties.getName() + "' brush! Setting up the default one...");
         return defaultValue;
     }
@@ -395,7 +399,7 @@ public abstract class AbstractBrush implements Brush {
             }
         }
 
-        plugin.getLogger().warning("Invalid or missing '" + registry.getName() + "' Registry property '" + propertyName +
+        PLUGIN.getLogger().warning("Invalid or missing '" + registry.getName() + "' Registry property '" + propertyName +
                 "' value for '" + this.properties.getName() + "' brush! Setting up the default one...");
         return defaultValue;
     }
@@ -411,7 +415,7 @@ public abstract class AbstractBrush implements Brush {
             }
         }
 
-        plugin.getLogger().warning("Invalid or missing '" + enumClass.getSimpleName() + "' Enum property '" + propertyName +
+        PLUGIN.getLogger().warning("Invalid or missing '" + enumClass.getSimpleName() + "' Enum property '" + propertyName +
                 "' value for '" + this.properties.getName() + "' brush! Setting up the default one...");
         return defaultValue;
     }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/AbstractBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/AbstractBrush.java
@@ -191,6 +191,17 @@ public abstract class AbstractBrush implements Brush {
         return null;
     }
 
+    public BlockVector3 getRelativeBlock(BlockVector3 origin, Direction direction) {
+        int x = origin.getX();
+        int y = origin.getY();
+        int z = origin.getZ();
+        return getRelativeBlock(x, y, z, direction);
+    }
+
+    public BlockVector3 getRelativeBlock(int x, int y, int z, Direction direction) {
+        return direction.toBlockVector().add(x, y, z);
+    }
+
     public BlockType getBlockType(BlockVector3 position) {
         int x = position.getX();
         int y = position.getY();

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/AbstractBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/AbstractBrush.java
@@ -107,7 +107,7 @@ public abstract class AbstractBrush implements Brush {
         }
     }
 
-    protected int clampY(int y) {
+    public int clampY(int y) {
         int clampedY = y;
         int minHeight = editSession.getMinY();
         if (clampedY <= minHeight) {
@@ -121,18 +121,18 @@ public abstract class AbstractBrush implements Brush {
         return clampedY;
     }
 
-    protected BlockState clampY(BlockVector3 position) {
+    public BlockState clampY(BlockVector3 position) {
         int x = position.getX();
         int y = position.getY();
         int z = position.getZ();
         return clampY(x, y, z);
     }
 
-    protected BlockState clampY(int x, int y, int z) {
+    public BlockState clampY(int x, int y, int z) {
         return getBlock(x, clampY(y), z);
     }
 
-    protected void setBiome(int x, int y, int z, BiomeType biomeType) {
+    public void setBiome(int x, int y, int z, BiomeType biomeType) {
         try {
             editSession.setBiome(x, y, z, biomeType);
         } catch (WorldEditException e) {
@@ -140,7 +140,7 @@ public abstract class AbstractBrush implements Brush {
         }
     }
 
-    protected int getHighestTerrainBlock(int x, int z, int minY, int maxY) {
+    public int getHighestTerrainBlock(int x, int z, int minY, int maxY) {
         try {
             return editSession.getHighestTerrainBlock(x, z, minY, maxY);
         } catch (WorldEditException e) {
@@ -148,7 +148,7 @@ public abstract class AbstractBrush implements Brush {
         }
     }
 
-    protected boolean regenerateChunk(int chunkX, int chunkZ, BiomeType biomeType) {
+    public boolean regenerateChunk(int chunkX, int chunkZ, BiomeType biomeType) {
         try {
             World world = BukkitAdapter.adapt(editSession.getWorld());
             int minX = chunkX << 4;
@@ -172,7 +172,7 @@ public abstract class AbstractBrush implements Brush {
         }
     }
 
-    protected void refreshChunk(int chunkX, int chunkZ) {
+    public void refreshChunk(int chunkX, int chunkZ) {
         try {
             editSession.getWorld().refreshChunk(chunkX, chunkZ);
         } catch (WorldEditException e) {
@@ -180,7 +180,7 @@ public abstract class AbstractBrush implements Brush {
         }
     }
 
-    protected boolean generateTree(BlockVector3 location, TreeGenerator.TreeType treeType) {
+    public boolean generateTree(BlockVector3 location, TreeGenerator.TreeType treeType) {
         try {
             return treeType.generate(editSession, location);
         } catch (WorldEditException e) {
@@ -188,14 +188,14 @@ public abstract class AbstractBrush implements Brush {
         }
     }
 
-    protected Entity createEntity(BlockVector3 location, org.bukkit.entity.Entity bukkitEntity) {
+    public Entity createEntity(BlockVector3 location, org.bukkit.entity.Entity bukkitEntity) {
         return editSession.createEntity(
                 new Location(editSession, location.getX(), location.getY(), location.getZ()),
                 BukkitAdapter.adapt(bukkitEntity).getState()
         );
     }
 
-    protected Direction getDirection(BlockVector3 first, BlockVector3 second) {
+    public Direction getDirection(BlockVector3 first, BlockVector3 second) {
         for (Direction direction : Direction.values()) {
             if (first.getX() + direction.getX() == second.getX()
                     && first.getY() + direction.getY() == second.getY()
@@ -206,48 +206,48 @@ public abstract class AbstractBrush implements Brush {
         return null;
     }
 
-    protected BlockVector3 getRelativeBlock(BlockVector3 origin, Direction direction) {
+    public BlockVector3 getRelativeBlock(BlockVector3 origin, Direction direction) {
         int x = origin.getX();
         int y = origin.getY();
         int z = origin.getZ();
         return getRelativeBlock(x, y, z, direction);
     }
 
-    protected BlockVector3 getRelativeBlock(int x, int y, int z, Direction direction) {
+    public BlockVector3 getRelativeBlock(int x, int y, int z, Direction direction) {
         return direction.toBlockVector().add(x, y, z);
     }
 
-    protected BlockType getBlockType(BlockVector3 position) {
+    public BlockType getBlockType(BlockVector3 position) {
         int x = position.getX();
         int y = position.getY();
         int z = position.getZ();
         return getBlockType(x, y, z);
     }
 
-    protected BlockType getBlockType(int x, int y, int z) {
+    public BlockType getBlockType(int x, int y, int z) {
         BlockState block = getBlock(x, y, z);
         return block.getBlockType();
     }
 
-    protected void setBlockType(BlockVector3 position, BlockType type) {
+    public void setBlockType(BlockVector3 position, BlockType type) {
         int x = position.getX();
         int y = position.getY();
         int z = position.getZ();
         setBlockType(x, y, z, type);
     }
 
-    protected void setBlockType(int x, int y, int z, BlockType type) {
+    public void setBlockType(int x, int y, int z, BlockType type) {
         setBlockData(x, y, z, type.getDefaultState());
     }
 
-    protected void setBlockData(BlockVector3 position, BlockState blockState) {
+    public void setBlockData(BlockVector3 position, BlockState blockState) {
         int x = position.getX();
         int y = position.getY();
         int z = position.getZ();
         setBlockData(x, y, z, blockState);
     }
 
-    protected void setBlockData(int x, int y, int z, BlockState blockState) {
+    public void setBlockData(int x, int y, int z, BlockState blockState) {
         editSession.setBlock(x, y, z, blockState);
         if (blockState.getMaterial().isTile()) {
             try {
@@ -258,36 +258,36 @@ public abstract class AbstractBrush implements Brush {
         }
     }
 
-    protected BaseBlock getFullBlock(BlockVector3 position) {
+    public BaseBlock getFullBlock(BlockVector3 position) {
         int x = position.getX();
         int y = position.getY();
         int z = position.getZ();
         return getFullBlock(x, y, z);
     }
 
-    protected BaseBlock getFullBlock(int x, int y, int z) {
+    public BaseBlock getFullBlock(int x, int y, int z) {
         return editSession.getFullBlock(x, y, z);
     }
 
-    protected BlockState getBlock(BlockVector3 position) {
+    public BlockState getBlock(BlockVector3 position) {
         int x = position.getX();
         int y = position.getY();
         int z = position.getZ();
         return getBlock(x, y, z);
     }
 
-    protected BlockState getBlock(int x, int y, int z) {
+    public BlockState getBlock(int x, int y, int z) {
         return editSession.getBlock(x, y, z);
     }
 
-    protected void setBlock(BlockVector3 position, BaseBlock block) {
+    public void setBlock(BlockVector3 position, BaseBlock block) {
         int x = position.getX();
         int y = position.getY();
         int z = position.getZ();
         setBlock(x, y, z, block);
     }
 
-    protected void setBlock(int x, int y, int z, BaseBlock block) {
+    public void setBlock(int x, int y, int z, BaseBlock block) {
         editSession.setBlock(x, y, z, block);
     }
 
@@ -303,7 +303,7 @@ public abstract class AbstractBrush implements Brush {
      * @param defaultValue the default value to set and return
      * @return the associated proprorty, or the default value
      */
-    protected Object getProperty(String propertyName, Object defaultValue) {
+    public Object getProperty(String propertyName, Object defaultValue) {
         return getProperty(propertyName, defaultValue, defaultValue);
     }
 
@@ -315,7 +315,7 @@ public abstract class AbstractBrush implements Brush {
      * @param defaultConfigValue the default config value to set, objets such as Enum and Registry values are not serializable*
      * @return the associated proprorty, or the default value
      */
-    protected Object getProperty(String propertyName, Object defaultValue, Object defaultConfigValue) {
+    public Object getProperty(String propertyName, Object defaultValue, Object defaultConfigValue) {
         String brush = this.properties.getName();
         Object currentPropertyValue = CONFIG.getBrushProperties()
                 .computeIfAbsent(brush, brushName -> new HashMap<>())
@@ -326,7 +326,7 @@ public abstract class AbstractBrush implements Brush {
         return currentPropertyValue;
     }
 
-    protected String getStringProperty(String propertyName, String defaultValue) {
+    public String getStringProperty(String propertyName, String defaultValue) {
         Object propertyValue = this.getProperty(propertyName, defaultValue);
 
         if (propertyValue instanceof String) {
@@ -338,7 +338,7 @@ public abstract class AbstractBrush implements Brush {
         return defaultValue;
     }
 
-    protected boolean getBooleanProperty(String propertyName, boolean defaultValue) {
+    public boolean getBooleanProperty(String propertyName, boolean defaultValue) {
         Object propertyValue = this.getProperty(propertyName, defaultValue);
 
         if (propertyValue instanceof Boolean) {
@@ -350,7 +350,7 @@ public abstract class AbstractBrush implements Brush {
         return defaultValue;
     }
 
-    protected int getIntegerProperty(String propertyName, int defaultValue) {
+    public int getIntegerProperty(String propertyName, int defaultValue) {
         Object propertyValue = this.getProperty(propertyName, defaultValue);
 
         if (propertyValue instanceof Integer) {
@@ -362,7 +362,7 @@ public abstract class AbstractBrush implements Brush {
         return defaultValue;
     }
 
-    protected double getDoubleProperty(String propertyName, double defaultValue) {
+    public double getDoubleProperty(String propertyName, double defaultValue) {
         Object propertyValue = this.getProperty(propertyName, defaultValue);
 
         if (propertyValue instanceof Double) {
@@ -374,7 +374,7 @@ public abstract class AbstractBrush implements Brush {
         return defaultValue;
     }
 
-    protected List<?> getListProperty(String propertyName, List<?> defaultValue) {
+    public List<?> getListProperty(String propertyName, List<?> defaultValue) {
         Object propertyValue = this.getProperty(propertyName, defaultValue);
 
         if (propertyValue instanceof List) {
@@ -386,7 +386,7 @@ public abstract class AbstractBrush implements Brush {
         return defaultValue;
     }
 
-    protected Object getRegistryProperty(
+    public Object getRegistryProperty(
             String propertyName, NamespacedRegistry<? extends Keyed> registry, Keyed
             defaultValue
     ) {
@@ -405,7 +405,7 @@ public abstract class AbstractBrush implements Brush {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    protected Enum<?> getEnumProperty(String propertyName, Class<?> enumClass, Enum<?> defaultValue) {
+    public Enum<?> getEnumProperty(String propertyName, Class<?> enumClass, Enum<?> defaultValue) {
         Object propertyValue = this.getProperty(propertyName, defaultValue, defaultValue.name());
 
         if (propertyValue instanceof String) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BiomeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BiomeBrush.java
@@ -100,7 +100,7 @@ public class BiomeBrush extends AbstractBrush {
             double xSquared = Math.pow(x, 2);
             for (int z = -brushSize; z <= brushSize; z++) {
                 if (xSquared + Math.pow(z, 2) <= brushSizeSquared) {
-                    for (int y = 0; y <= editSession.getMaxY(); ++y) {
+                    for (int y = editSession.getMinY(); y <= editSession.getMaxY(); ++y) {
                         setBiome(targetBlockX + x, y, targetBlockZ + z, this.biomeType);
                     }
                 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BiomeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BiomeBrush.java
@@ -16,11 +16,18 @@ import java.util.stream.Stream;
 
 public class BiomeBrush extends AbstractBrush {
 
+    private static final BiomeType DEFAULT_BIOME_TYPE = BiomeTypes.PLAINS;
+
     private static final List<String> BIOMES = BiomeTypes.values().stream()
             .map(biomeType -> biomeType.getId().substring(Identifiers.MINECRAFT_IDENTIFIER_LENGTH))
             .collect(Collectors.toList());
 
-    private BiomeType biomeType = BiomeTypes.PLAINS;
+    private BiomeType biomeType;
+
+    @Override
+    public void loadProperties() {
+        this.biomeType = (BiomeType) getRegistryProperty("default-biome-type", BiomeType.REGISTRY, DEFAULT_BIOME_TYPE);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BiomeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BiomeBrush.java
@@ -54,7 +54,7 @@ public class BiomeBrush extends AbstractBrush {
 
                     if (biomeType != null) {
                         this.biomeType = biomeType;
-                        messenger.sendMessage(ChatColor.GOLD + "Biome type set to " + ChatColor.DARK_GREEN + this.biomeType.getId());
+                        messenger.sendMessage(ChatColor.GOLD + "Biome type set to: " + ChatColor.DARK_GREEN + this.biomeType.getId());
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid biome type.");
                     }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BiomeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BiomeBrush.java
@@ -91,7 +91,7 @@ public class BiomeBrush extends AbstractBrush {
             double xSquared = Math.pow(x, 2);
             for (int z = -brushSize; z <= brushSize; z++) {
                 if (xSquared + Math.pow(z, 2) <= brushSizeSquared) {
-                    for (int y = 0; y < editSession.getMaxY() + 1; ++y) {
+                    for (int y = 0; y <= editSession.getMaxY(); ++y) {
                         setBiome(targetBlockX + x, y, targetBlockZ + z, this.biomeType);
                     }
                 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BiomeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BiomeBrush.java
@@ -38,7 +38,9 @@ public class BiomeBrush extends AbstractBrush {
                             BiomeTypes.values().stream()
                                     .map(biomeType -> ((biomeType == this.biomeType) ? ChatColor.GOLD : ChatColor.GRAY) +
                                             biomeType.getId().substring(Identifiers.MINECRAFT_IDENTIFIER_LENGTH))
-                                    .collect(Collectors.joining(ChatColor.WHITE + ", "))
+                                    .collect(Collectors.joining(ChatColor.WHITE + ", ",
+                                            ChatColor.AQUA + "Available biomes: ", ""
+                                    ))
                     );
                 } else {
                     BiomeType biomeType = BiomeTypes.get(firstParameter);

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BlockResetBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BlockResetBrush.java
@@ -14,13 +14,16 @@ public class BlockResetBrush extends AbstractBrush {
 
     private static final MaterialSet DENIED_UPDATES = MaterialSet.builder()
             .with(BlockCategories.DOORS)
+            .with(BlockCategories.TRAPDOORS)
             .with(BlockCategories.SIGNS)
             .with(MaterialSets.CHESTS)
-            .with(MaterialSets.REDSTONE_TORCHES)
             .with(BlockCategories.FENCE_GATES)
             .add(BlockTypes.FURNACE)
+            .add(BlockTypes.REDSTONE_TORCH)
+            .add(BlockTypes.REDSTONE_WALL_TORCH)
             .add(BlockTypes.REDSTONE_WIRE)
             .add(BlockTypes.REPEATER)
+            .add(BlockTypes.COMPARATOR)
             .build();
 
     @Override

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/CopyPastaBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/CopyPastaBrush.java
@@ -14,6 +14,9 @@ import java.util.stream.Stream;
 public class CopyPastaBrush extends AbstractBrush {
 
     private static final int BLOCK_LIMIT = 10000;
+
+    private int blockLimit;
+
     private final int[] pastePoint = new int[3];
     private final int[] minPoint = new int[3];
     private final int[] offsetPoint = new int[3];
@@ -26,6 +29,11 @@ public class CopyPastaBrush extends AbstractBrush {
     private BlockType[] blockArray;
     private BlockState[] dataArray;
     private int pivot; // ccw degrees
+
+    @Override
+    public void loadProperties() {
+        this.blockLimit = getIntegerProperty("block-limit", BLOCK_LIMIT);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
@@ -97,7 +105,7 @@ public class CopyPastaBrush extends AbstractBrush {
         if (this.points == 2) {
             if (this.numBlocks == 0) {
                 doCopy(snipe);
-            } else if (this.numBlocks > 0 && this.numBlocks < BLOCK_LIMIT) {
+            } else if (this.numBlocks > 0 && this.numBlocks < this.blockLimit) {
                 BlockVector3 targetBlock = this.getTargetBlock();
                 this.pastePoint[0] = targetBlock.getX();
                 this.pastePoint[1] = targetBlock.getY();
@@ -119,7 +127,7 @@ public class CopyPastaBrush extends AbstractBrush {
         }
         this.numBlocks = (this.arraySize[0]) * (this.arraySize[1]) * (this.arraySize[2]);
         SnipeMessenger messenger = snipe.createMessenger();
-        if (this.numBlocks > 0 && this.numBlocks < BLOCK_LIMIT) {
+        if (this.numBlocks > 0 && this.numBlocks < this.blockLimit) {
             this.blockArray = new BlockType[this.numBlocks];
             this.dataArray = new BlockState[this.numBlocks];
             for (int i = 0; i < this.arraySize[0]; i++) {
@@ -135,7 +143,7 @@ public class CopyPastaBrush extends AbstractBrush {
             }
             messenger.sendMessage(ChatColor.AQUA + String.valueOf(this.numBlocks) + " blocks copied.");
         } else {
-            messenger.sendMessage(ChatColor.RED + "Copy area too big: " + this.numBlocks + "(Limit: " + BLOCK_LIMIT + ")");
+            messenger.sendMessage(ChatColor.RED + "Copy area too big: " + this.numBlocks + "(Limit: " + this.blockLimit + ")");
         }
     }
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/CopyPastaBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/CopyPastaBrush.java
@@ -48,11 +48,11 @@ public class CopyPastaBrush extends AbstractBrush {
             if (parameters.length == 1) {
                 if (firstParameter.equalsIgnoreCase("air")) {
                     this.pasteAir = !this.pasteAir;
-                    messenger.sendMessage(ChatColor.GOLD + "Paste air set to " + this.pasteAir);
+                    messenger.sendMessage(ChatColor.GOLD + "Paste air set to: " + this.pasteAir);
                 } else if (Stream.of("0", "90", "180", "270")
                         .anyMatch(firstParameter::equalsIgnoreCase)) {
                     this.pivot = Integer.parseInt(firstParameter);
-                    messenger.sendMessage(ChatColor.GOLD + "Pivot angle set to " + this.pivot);
+                    messenger.sendMessage(ChatColor.GOLD + "Pivot angle set to: " + this.pivot);
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid brush parameters! Use the \"info\" parameter to display parameter info.");
                 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ErodeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ErodeBrush.java
@@ -54,7 +54,7 @@ public class ErodeBrush extends AbstractBrush {
             if (preset != null) {
                 try {
                     this.currentPreset = preset.getPreset();
-                    messenger.sendMessage(ChatColor.LIGHT_PURPLE + "Brush preset set to " + preset.getName());
+                    messenger.sendMessage(ChatColor.LIGHT_PURPLE + "Brush preset set to: " + preset.getName());
                     return;
                 } catch (IllegalArgumentException exception) {
                     messenger.sendMessage(ChatColor.RED + "Invalid preset.");
@@ -275,10 +275,10 @@ public class ErodeBrush extends AbstractBrush {
         SnipeMessenger messenger = snipe.createMessenger();
         messenger.sendBrushNameMessage();
         messenger.sendBrushSizeMessage();
-        messenger.sendMessage(ChatColor.AQUA + "Erosion minimum exposed faces set to " + this.currentPreset.getErosionFaces());
-        messenger.sendMessage(ChatColor.BLUE + "Fill minumum touching faces set to " + this.currentPreset.getFillFaces());
-        messenger.sendMessage(ChatColor.BLUE + "Erosion recursion amount set to " + this.currentPreset.getErosionRecursion());
-        messenger.sendMessage(ChatColor.DARK_GREEN + "Fill recursion amount set to " + this.currentPreset.getFillRecursion());
+        messenger.sendMessage(ChatColor.AQUA + "Erosion minimum exposed faces set to: " + this.currentPreset.getErosionFaces());
+        messenger.sendMessage(ChatColor.BLUE + "Fill minumum touching faces set to: " + this.currentPreset.getFillFaces());
+        messenger.sendMessage(ChatColor.BLUE + "Erosion recursion amount set to: " + this.currentPreset.getErosionRecursion());
+        messenger.sendMessage(ChatColor.DARK_GREEN + "Fill recursion amount set to: " + this.currentPreset.getFillRecursion());
     }
 
     private enum Preset {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ErodeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ErodeBrush.java
@@ -2,6 +2,7 @@ package com.thevoxelbox.voxelsniper.brush.type;
 
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
@@ -26,13 +27,13 @@ import java.util.stream.Stream;
 
 public class ErodeBrush extends AbstractBrush {
 
-    private static final List<BlockVector3> FACES_TO_CHECK = Arrays.asList(
-            BlockVector3.at(0, 0, 1),
-            BlockVector3.at(0, 0, -1),
-            BlockVector3.at(0, 1, 0),
-            BlockVector3.at(0, -1, 0),
-            BlockVector3.at(1, 0, 0),
-            BlockVector3.at(-1, 0, 0)
+    private static final List<Direction> FACES_TO_CHECK = Arrays.asList(
+            Direction.SOUTH,
+            Direction.NORTH,
+            Direction.UP,
+            Direction.DOWN,
+            Direction.EAST,
+            Direction.WEST
     );
 
     private ErosionPreset currentPreset = new ErosionPreset(0, 1, 0, 1);
@@ -195,8 +196,10 @@ public class ErodeBrush extends AbstractBrush {
                         }
                         int count = 0;
                         Map<BlockWrapper, Integer> blockCount = new HashMap<>();
-                        for (BlockVector3 vector : FACES_TO_CHECK) {
-                            Vector relativePosition = Vectors.toBukkit(Vectors.of(currentPosition).add(vector));
+                        for (Direction direction : FACES_TO_CHECK) {
+                            Vector relativePosition = Vectors.toBukkit(
+                                    getRelativeBlock(Vectors.of(currentPosition), direction)
+                            );
                             BlockWrapper relativeBlock = blockChangeTracker.get(relativePosition, currentIteration);
                             if (!(relativeBlock.isEmpty() || relativeBlock.isLiquid())) {
                                 count++;
@@ -249,7 +252,7 @@ public class ErodeBrush extends AbstractBrush {
                             continue;
                         }
                         int count = (int) FACES_TO_CHECK.stream()
-                                .map(vector -> Vectors.of(currentPosition).add(vector))
+                                .map(direction -> getRelativeBlock(Vectors.of(currentPosition), direction))
                                 .map(Vectors::toBukkit)
                                 .map(relativePosition -> blockChangeTracker.get(relativePosition, currentIteration))
                                 .filter(relativeBlock -> relativeBlock.isEmpty() || relativeBlock.isLiquid())

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/FlatOceanBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/FlatOceanBrush.java
@@ -36,20 +36,18 @@ public class FlatOceanBrush extends AbstractBrush {
         } else {
             if (parameters.length == 2) {
                 if (firstParameter.equalsIgnoreCase("yo")) {
-                    String newWaterLevelString = parameters[1];
-                    Integer newWaterLevel = NumericParser.parseInteger(newWaterLevelString);
+                    Integer newWaterLevel = NumericParser.parseInteger(parameters[1]);
                     if (newWaterLevel != null) {
                         if (newWaterLevel < this.floorLevel) {
                             newWaterLevel = this.floorLevel + 1;
                         }
                         this.waterLevel = newWaterLevel;
-                        messenger.sendMessage(ChatColor.GREEN + "Water level set to " + this.waterLevel);
+                        messenger.sendMessage(ChatColor.GREEN + "Water level set to: " + this.waterLevel);
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");
                     }
                 } else if (firstParameter.equalsIgnoreCase("yl")) {
-                    String newFloorLevelString = parameters[1];
-                    Integer newFloorLevel = NumericParser.parseInteger(newFloorLevelString);
+                    Integer newFloorLevel = NumericParser.parseInteger(parameters[1]);
                     if (newFloorLevel != null) {
                         if (newFloorLevel > this.waterLevel) {
                             newFloorLevel = this.waterLevel - 1;
@@ -59,7 +57,7 @@ public class FlatOceanBrush extends AbstractBrush {
                             }
                         }
                         this.floorLevel = newFloorLevel;
-                        messenger.sendMessage(ChatColor.GREEN + "Ocean floor level set to " + this.floorLevel);
+                        messenger.sendMessage(ChatColor.GREEN + "Ocean floor level set to: " + this.floorLevel);
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");
                     }
@@ -135,8 +133,8 @@ public class FlatOceanBrush extends AbstractBrush {
     public void sendInfo(Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
         messenger.sendBrushNameMessage();
-        messenger.sendMessage(ChatColor.GREEN + "Water level set to " + this.waterLevel);
-        messenger.sendMessage(ChatColor.GREEN + "Ocean floor level set to " + this.floorLevel);
+        messenger.sendMessage(ChatColor.GREEN + "Water level set to: " + this.waterLevel);
+        messenger.sendMessage(ChatColor.GREEN + "Ocean floor level set to: " + this.floorLevel);
     }
 
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/FlatOceanBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/FlatOceanBrush.java
@@ -47,13 +47,14 @@ public class FlatOceanBrush extends AbstractBrush {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");
                     }
                 } else if (firstParameter.equalsIgnoreCase("yl")) {
+                    EditSession editSession = getEditSession();
                     Integer newFloorLevel = NumericParser.parseInteger(parameters[1]);
                     if (newFloorLevel != null) {
                         if (newFloorLevel > this.waterLevel) {
                             newFloorLevel = this.waterLevel - 1;
-                            if (newFloorLevel == 0) {
-                                newFloorLevel = 1;
-                                this.waterLevel = 2;
+                            if (newFloorLevel <= editSession.getMinY()) {
+                                newFloorLevel = editSession.getMinY() + 1;
+                                this.waterLevel = editSession.getMinY() + 2;
                             }
                         }
                         this.floorLevel = newFloorLevel;

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/FlatOceanBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/FlatOceanBrush.java
@@ -112,7 +112,7 @@ public class FlatOceanBrush extends AbstractBrush {
         int blockZ = chunkZ << 4;
         for (int x = 0; x < CHUNK_SIZE; x++) {
             for (int z = 0; z < CHUNK_SIZE; z++) {
-                for (int y = 0; y < editSession.getMaxY() + 1; y++) {
+                for (int y = 0; y <= editSession.getMaxY(); y++) {
                     if (y <= this.floorLevel) {
                         setBlockType(blockX + x, y, blockZ + z, BlockTypes.DIRT);
                     } else if (y <= this.waterLevel) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/FlatOceanBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/FlatOceanBrush.java
@@ -118,7 +118,7 @@ public class FlatOceanBrush extends AbstractBrush {
         int blockZ = chunkZ << 4;
         for (int x = 0; x < CHUNK_SIZE; x++) {
             for (int z = 0; z < CHUNK_SIZE; z++) {
-                for (int y = 0; y <= editSession.getMaxY(); y++) {
+                for (int y = editSession.getMinY(); y <= editSession.getMaxY(); y++) {
                     if (y <= this.floorLevel) {
                         setBlockType(blockX + x, y, blockZ + z, BlockTypes.DIRT);
                     } else if (y <= this.waterLevel) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/FlatOceanBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/FlatOceanBrush.java
@@ -16,8 +16,14 @@ public class FlatOceanBrush extends AbstractBrush {
     private static final int DEFAULT_WATER_LEVEL = 29;
     private static final int DEFAULT_FLOOR_LEVEL = 8;
 
-    private int waterLevel = DEFAULT_WATER_LEVEL;
-    private int floorLevel = DEFAULT_FLOOR_LEVEL;
+    private int waterLevel;
+    private int floorLevel;
+
+    @Override
+    public void loadProperties() {
+        this.waterLevel = getIntegerProperty("default-water-level", DEFAULT_WATER_LEVEL);
+        this.floorLevel = getIntegerProperty("default-floor-level", DEFAULT_FLOOR_LEVEL);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/GenerateTreeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/GenerateTreeBrush.java
@@ -126,7 +126,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                     BlockType leafType = BlockTypes.get(parameters[1]);
                     if (leafType != null) {
                         this.leafType = leafType;
-                        messenger.sendMessage(ChatColor.BLUE + "Leaf Type set to " + this.leafType.getId());
+                        messenger.sendMessage(ChatColor.BLUE + "Leaf Type set to: " + this.leafType.getId());
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid leaf type.");
                     }
@@ -134,7 +134,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                     BlockType woodType = BlockTypes.get(parameters[1]);
                     if (woodType != null) {
                         this.woodType = woodType;
-                        messenger.sendMessage(ChatColor.BLUE + "Wood Type set to " + this.woodType.getId());
+                        messenger.sendMessage(ChatColor.BLUE + "Wood Type set to: " + this.woodType.getId());
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid wood type.");
                     }
@@ -142,18 +142,18 @@ public class GenerateTreeBrush extends AbstractBrush {
                     Integer thickness = NumericParser.parseInteger(parameters[1]);
                     if (thickness != null) {
                         this.thickness = thickness;
-                        messenger.sendMessage(ChatColor.BLUE + "Thickness set to " + this.thickness);
+                        messenger.sendMessage(ChatColor.BLUE + "Thickness set to: " + this.thickness);
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");
                     }
                 } else if (firstParameter.equalsIgnoreCase("rf")) { // Root Float
                     this.rootFloat = Boolean.parseBoolean(parameters[1]);
-                    messenger.sendMessage(ChatColor.BLUE + "Floating Roots set to " + this.rootFloat);
+                    messenger.sendMessage(ChatColor.BLUE + "Floating Roots set to: " + this.rootFloat);
                 } else if (firstParameter.equalsIgnoreCase("sh")) { // Starting Height
                     Integer startHeight = NumericParser.parseInteger(parameters[1]);
                     if (startHeight != null) {
                         this.startHeight = startHeight;
-                        messenger.sendMessage(ChatColor.BLUE + "Starting Height set to " + this.startHeight);
+                        messenger.sendMessage(ChatColor.BLUE + "Starting Height set to: " + this.startHeight);
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");
                     }
@@ -161,7 +161,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                     Integer rootLength = NumericParser.parseInteger(parameters[1]);
                     if (rootLength != null) {
                         this.rootLength = rootLength;
-                        messenger.sendMessage(ChatColor.BLUE + "Root Length set to " + this.rootLength);
+                        messenger.sendMessage(ChatColor.BLUE + "Root Length set to: " + this.rootLength);
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");
                     }
@@ -169,7 +169,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                     Integer slopeChance = NumericParser.parseInteger(parameters[1]);
                     if (slopeChance != null && slopeChance >= 0 && slopeChance <= 100) {
                         this.slopeChance = slopeChance;
-                        messenger.sendMessage(ChatColor.BLUE + "Trunk Slope set to " + this.slopeChance);
+                        messenger.sendMessage(ChatColor.BLUE + "Trunk Slope set to: " + this.slopeChance);
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");
                     }
@@ -177,7 +177,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                     Integer branchLenght = NumericParser.parseInteger(parameters[1]);
                     if (branchLenght != null) {
                         this.branchLength = branchLenght;
-                        messenger.sendMessage(ChatColor.BLUE + "Branch Length set to " + this.branchLength);
+                        messenger.sendMessage(ChatColor.BLUE + "Branch Length set to: " + this.branchLength);
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");
                     }
@@ -187,9 +187,9 @@ public class GenerateTreeBrush extends AbstractBrush {
                         this.minRoots = minRoots;
                         if (this.minRoots > this.maxRoots) {
                             this.minRoots = this.maxRoots;
-                            messenger.sendMessage(ChatColor.RED + "Minimum Roots can't exceed Maximum Roots, has been set to " + this.minRoots + " instead!");
+                            messenger.sendMessage(ChatColor.RED + "Minimum Roots can't exceed Maximum Roots, has been set to: " + this.minRoots + " instead!");
                         } else {
-                            messenger.sendMessage(ChatColor.BLUE + "Minimum Roots set to " + this.minRoots);
+                            messenger.sendMessage(ChatColor.BLUE + "Minimum Roots set to: " + this.minRoots);
                         }
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");
@@ -200,9 +200,9 @@ public class GenerateTreeBrush extends AbstractBrush {
                         this.maxRoots = maxRoots;
                         if (this.minRoots > this.maxRoots) {
                             this.maxRoots = this.minRoots;
-                            messenger.sendMessage(ChatColor.RED + "Maximum Roots can't be lower than Minimum Roots, has been set to " + this.minRoots + " Instead!");
+                            messenger.sendMessage(ChatColor.RED + "Maximum Roots can't be lower than Minimum Roots, has been set to: " + this.minRoots + " Instead!");
                         } else {
-                            messenger.sendMessage(ChatColor.BLUE + "Maximum Roots set to " + this.maxRoots);
+                            messenger.sendMessage(ChatColor.BLUE + "Maximum Roots set to: " + this.maxRoots);
                         }
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");
@@ -213,9 +213,9 @@ public class GenerateTreeBrush extends AbstractBrush {
                         this.heightMin = heightMinimum;
                         if (this.heightMin > this.heightMax) {
                             this.heightMin = this.heightMax;
-                            messenger.sendMessage(ChatColor.RED + "Minimum Height exceed than Maximum Height, has been set to " + this.heightMin + " Instead!");
+                            messenger.sendMessage(ChatColor.RED + "Minimum Height exceed than Maximum Height, has been set to: " + this.heightMin + " Instead!");
                         } else {
-                            messenger.sendMessage(ChatColor.BLUE + "Minimum Height set to " + this.heightMin);
+                            messenger.sendMessage(ChatColor.BLUE + "Minimum Height set to: " + this.heightMin);
                         }
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");
@@ -226,9 +226,9 @@ public class GenerateTreeBrush extends AbstractBrush {
                         this.heightMax = heightMaximum;
                         if (this.heightMin > this.heightMax) {
                             this.heightMax = this.heightMin;
-                            messenger.sendMessage(ChatColor.RED + "Maximum Height can't be lower than Minimum Height, has been set to " + this.heightMax + " Instead!");
+                            messenger.sendMessage(ChatColor.RED + "Maximum Height can't be lower than Minimum Height, has been set to: " + this.heightMax + " Instead!");
                         } else {
-                            messenger.sendMessage(ChatColor.BLUE + "Maximum Roots set to " + this.heightMax);
+                            messenger.sendMessage(ChatColor.BLUE + "Maximum Roots set to: " + this.heightMax);
                         }
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");
@@ -237,7 +237,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                     Integer nodeMin = NumericParser.parseInteger(parameters[1]);
                     if (nodeMin != null) {
                         this.nodeMin = nodeMin;
-                        messenger.sendMessage(ChatColor.BLUE + "Leaf Min Thickness set to " + this.nodeMin + " (Default 3)");
+                        messenger.sendMessage(ChatColor.BLUE + "Leaf Min Thickness set to: " + this.nodeMin);
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");
                     }
@@ -245,7 +245,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                     Integer nodeMax = NumericParser.parseInteger(parameters[1]);
                     if (nodeMax != null) {
                         this.nodeMax = nodeMax;
-                        messenger.sendMessage(ChatColor.BLUE + "Leaf Max Thickness set to " + this.nodeMax + " (Default 4)");
+                        messenger.sendMessage(ChatColor.BLUE + "Leaf Max Thickness set to: " + this.nodeMax);
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");
                     }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/GenerateTreeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/GenerateTreeBrush.java
@@ -20,6 +20,21 @@ import java.util.stream.Stream;
 // Proposal: Use /v and /vr for leave and wood material // or two more parameters -- Monofraps
 public class GenerateTreeBrush extends AbstractBrush {
 
+    private static final BlockType DEFAULT_LEAF_TYPE = BlockTypes.OAK_LEAVES;
+    private static final BlockType DEFAULT_WOOD_TYPE = BlockTypes.OAK_LOG;
+    private static final boolean DEFAULT_ROOT_FLOAT = false;
+    private static final int DEFAULT_START_HEIGHT = 0;
+    private static final int DEFAULT_ROOT_LENGTH = 9;
+    private static final int DEFAULT_MIN_ROOTS = 1;
+    private static final int DEFAULT_MAX_ROOTS = 2;
+    private static final int DEFAULT_THICKNESS = 1;
+    private static final int DEFAULT_SLOPE_CHANCE = 40;
+    private static final int DEFAULT_HEIGHT_MIN = 14;
+    private static final int DEFAULT_HEIGHT_MAX = 18;
+    private static final int DEFAULT_BRANCH_LENGTH = 8;
+    private static final int DEFAULT_NODE_MIN = 3;
+    private static final int DEFAULT_NODE_MAX = 4;
+
     private static final MaterialSet SOLIDS = MaterialSet.builder()
             .with(BlockCategories.LOGS)
             .with(MaterialSets.AIRS)
@@ -27,27 +42,50 @@ public class GenerateTreeBrush extends AbstractBrush {
             .add(BlockTypes.SNOW)
             .build();
 
-    // Tree Variables.
+    // Tree variables.
     private final Random randGenerator = new Random();
     private final List<BlockVector3> branchBlocksLocation = new ArrayList<>();
-    // If these default values are edited. Remember to change default values in the default preset.
-    private BlockType leafType = BlockTypes.OAK_LEAVES;
-    private BlockType woodType = BlockTypes.OAK_LOG;
+
+    private BlockType leafType;
+    private BlockType woodType;
     private boolean rootFloat;
     private int startHeight;
-    private int rootLength = 9;
-    private int maxRoots = 2;
-    private int minRoots = 1;
-    private int thickness = 1;
-    private int slopeChance = 40;
-    private int heightMinimum = 14;
-    private int heightMaximum = 18;
-    private int branchLength = 8;
-    private int nodeMax = 4;
-    private int nodeMin = 3;
+    private int rootLength;
+    private int minRoots;
+    private int maxRoots;
+    private int thickness;
+    private int slopeChance;
+    private int heightMin;
+    private int heightMax;
+    private int branchLength;
+    private int nodeMin;
+    private int nodeMax;
+
     private int blockPositionX;
     private int blockPositionY;
     private int blockPositionZ;
+
+    @Override
+    public void loadProperties() {
+        resetValues();
+    }
+
+    private void resetValues() {
+        this.leafType = (BlockType) getRegistryProperty("default-leaf-type", BlockType.REGISTRY, DEFAULT_LEAF_TYPE);
+        this.woodType = (BlockType) getRegistryProperty("default-wood-type", BlockType.REGISTRY, DEFAULT_WOOD_TYPE);
+        this.rootFloat = getBooleanProperty("default-root-float", DEFAULT_ROOT_FLOAT);
+        this.startHeight = getIntegerProperty("default-start-height", DEFAULT_START_HEIGHT);
+        this.rootLength = getIntegerProperty("default-root-length", DEFAULT_ROOT_LENGTH);
+        this.minRoots = getIntegerProperty("default-min-roots", DEFAULT_MIN_ROOTS);
+        this.maxRoots = getIntegerProperty("default-max-roots", DEFAULT_MAX_ROOTS);
+        this.thickness = getIntegerProperty("default-thickness", DEFAULT_THICKNESS);
+        this.slopeChance = getIntegerProperty("default-slope-chance", DEFAULT_SLOPE_CHANCE);
+        this.heightMin = getIntegerProperty("default-height-min", DEFAULT_HEIGHT_MIN);
+        this.heightMax = getIntegerProperty("default-height-max", DEFAULT_HEIGHT_MAX);
+        this.branchLength = getIntegerProperty("default-branch-length", DEFAULT_BRANCH_LENGTH);
+        this.nodeMin = getIntegerProperty("default-node-min", DEFAULT_NODE_MIN);
+        this.nodeMax = getIntegerProperty("default-node-max", DEFAULT_NODE_MAX);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
@@ -77,27 +115,13 @@ public class GenerateTreeBrush extends AbstractBrush {
                     // -------
                     // Presets
                     // -------
-                    this.leafType = BlockTypes.OAK_LEAVES;
-                    this.woodType = BlockTypes.OAK_LOG;
-                    this.rootFloat = false;
-                    this.startHeight = 0;
-                    this.rootLength = 9;
-                    this.maxRoots = 2;
-                    this.minRoots = 1;
-                    this.thickness = 1;
-                    this.slopeChance = 40;
-                    this.heightMinimum = 14;
-                    this.heightMaximum = 18;
-                    this.branchLength = 8;
-                    this.nodeMax = 4;
-                    this.nodeMin = 3;
+                    resetValues();
                     messenger.sendMessage(ChatColor.GOLD + "Brush reset to default parameters.");
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid brush parameters! Use the \"info\" parameter to display parameter " +
                             "info.");
                 }
             } else if (parameters.length == 2) {
-
                 if (firstParameter.equalsIgnoreCase("lt")) { // Leaf Type
                     BlockType leafType = BlockTypes.get(parameters[1]);
                     if (leafType != null) {
@@ -186,12 +210,12 @@ public class GenerateTreeBrush extends AbstractBrush {
                 } else if (firstParameter.equalsIgnoreCase("minh")) { // Height Minimum
                     Integer heightMinimum = NumericParser.parseInteger(parameters[1]);
                     if (heightMinimum != null) {
-                        this.heightMinimum = heightMinimum;
-                        if (this.heightMinimum > this.heightMaximum) {
-                            this.heightMinimum = this.heightMaximum;
-                            messenger.sendMessage(ChatColor.RED + "Minimum Height exceed than Maximum Height, has been set to " + this.heightMinimum + " Instead!");
+                        this.heightMin = heightMinimum;
+                        if (this.heightMin > this.heightMax) {
+                            this.heightMin = this.heightMax;
+                            messenger.sendMessage(ChatColor.RED + "Minimum Height exceed than Maximum Height, has been set to " + this.heightMin + " Instead!");
                         } else {
-                            messenger.sendMessage(ChatColor.BLUE + "Minimum Height set to " + this.heightMinimum);
+                            messenger.sendMessage(ChatColor.BLUE + "Minimum Height set to " + this.heightMin);
                         }
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");
@@ -199,12 +223,12 @@ public class GenerateTreeBrush extends AbstractBrush {
                 } else if (firstParameter.equalsIgnoreCase("maxh")) { // Height Maximum
                     Integer heightMaximum = NumericParser.parseInteger(parameters[1]);
                     if (heightMaximum != null) {
-                        this.heightMaximum = heightMaximum;
-                        if (this.heightMinimum > this.heightMaximum) {
-                            this.heightMaximum = this.heightMinimum;
-                            messenger.sendMessage(ChatColor.RED + "Maximum Height can't be lower than Minimum Height, has been set to " + this.heightMaximum + " Instead!");
+                        this.heightMax = heightMaximum;
+                        if (this.heightMin > this.heightMax) {
+                            this.heightMax = this.heightMin;
+                            messenger.sendMessage(ChatColor.RED + "Maximum Height can't be lower than Minimum Height, has been set to " + this.heightMax + " Instead!");
                         } else {
-                            messenger.sendMessage(ChatColor.BLUE + "Maximum Roots set to " + this.heightMaximum);
+                            messenger.sendMessage(ChatColor.BLUE + "Maximum Roots set to " + this.heightMax);
                         }
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");
@@ -475,7 +499,7 @@ public class GenerateTreeBrush extends AbstractBrush {
             zDirection = -1;
         }
         // Generates a height for trunk.
-        int height = this.randGenerator.nextInt(this.heightMaximum - this.heightMinimum + 1) + this.heightMinimum;
+        int height = this.randGenerator.nextInt(this.heightMax - this.heightMin + 1) + this.heightMin;
         // This is a hidden value not available through Parameters. Otherwise messy.
         int twistChance = 5;
         for (int p = 0; p < height; p++) {
@@ -523,7 +547,7 @@ public class GenerateTreeBrush extends AbstractBrush {
             nextZDirection = -1;
         }
         // Generates a height for trunk.
-        int nextHeight = this.randGenerator.nextInt(this.heightMaximum - this.heightMinimum + 1) + this.heightMinimum;
+        int nextHeight = this.randGenerator.nextInt(this.heightMax - this.heightMin + 1) + this.heightMin;
         if (nextHeight > 4) {
             for (int p = 0; p < nextHeight; p++) {
                 if (this.randGenerator.nextInt(100) <= twistChance) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/HeatRayBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/HeatRayBrush.java
@@ -27,6 +27,11 @@ public class HeatRayBrush extends AbstractBrush {
     private static final double REQUIRED_COBBLE_DENSITY = 0.5;
     private static final double REQUIRED_FIRE_DENSITY = -0.25;
     private static final double REQUIRED_AIR_DENSITY = 0;
+
+    private static final int DEFAULT_OCTAVES = 5;
+    private static final double DEFAULT_FREQUENCY = 1;
+    private static final double DEFAULT_AMPLITUDE = 0.3;
+
     private static final MaterialSet FLAMEABLE_BLOCKS = MaterialSet.builder()
             .with(BlockCategories.LOGS)
             .with(BlockCategories.SAPLINGS)
@@ -51,9 +56,26 @@ public class HeatRayBrush extends AbstractBrush {
             .add(BlockTypes.LADDER)
             .build();
 
-    private int octaves = 5;
-    private double frequency = 1;
-    private double amplitude = 0.3;
+    private double requiredObsidianDensity;
+    private double requiredCobbleDensity;
+    private double requiredFireDensity;
+    private double requiredAirDensity;
+
+    private int octaves;
+    private double frequency;
+    private double amplitude;
+
+    @Override
+    public void loadProperties() {
+        this.requiredObsidianDensity = getDoubleProperty("required-obsidian-density", REQUIRED_OBSIDIAN_DENSITY);
+        this.requiredCobbleDensity = getDoubleProperty("required-cobble-density", REQUIRED_COBBLE_DENSITY);
+        this.requiredFireDensity = getDoubleProperty("required-fire-density", REQUIRED_FIRE_DENSITY);
+        this.requiredAirDensity = getDoubleProperty("required-air-density", REQUIRED_AIR_DENSITY);
+
+        this.octaves = getIntegerProperty("default-octaves", DEFAULT_OCTAVES);
+        this.frequency = getDoubleProperty("default-frequency", DEFAULT_FREQUENCY);
+        this.amplitude = getDoubleProperty("default-amplitude", DEFAULT_AMPLITUDE);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
@@ -144,7 +166,7 @@ public class HeatRayBrush extends AbstractBrush {
                                 currentLocation.getBlockZ()
                         );
                         BlockType currentBlockType = currentBlock.getBlockType();
-                        if (currentBlockType == BlockTypes.CHEST) {
+                        if (MaterialSets.CHESTS.contains(currentBlockType)) {
                             continue;
                         }
                         if (Materials.isLiquid(currentBlockType)) {
@@ -198,7 +220,7 @@ public class HeatRayBrush extends AbstractBrush {
                                     this.frequency,
                                     this.amplitude
                             );
-                            if (obsidianDensity >= REQUIRED_OBSIDIAN_DENSITY) {
+                            if (obsidianDensity >= this.requiredObsidianDensity) {
                                 if (currentBlockType != BlockTypes.OBSIDIAN) {
                                     setBlockType(
                                             currentLocation.getBlockX(),
@@ -207,7 +229,7 @@ public class HeatRayBrush extends AbstractBrush {
                                             BlockTypes.OBSIDIAN
                                     );
                                 }
-                            } else if (cobbleDensity >= REQUIRED_COBBLE_DENSITY) {
+                            } else if (cobbleDensity >= this.requiredCobbleDensity) {
                                 if (currentBlockType != BlockTypes.COBBLESTONE) {
                                     setBlockType(
                                             currentLocation.getBlockX(),
@@ -216,7 +238,7 @@ public class HeatRayBrush extends AbstractBrush {
                                             BlockTypes.COBBLESTONE
                                     );
                                 }
-                            } else if (fireDensity >= REQUIRED_FIRE_DENSITY) {
+                            } else if (fireDensity >= this.requiredFireDensity) {
                                 if (currentBlockType != BlockTypes.FIRE) {
                                     setBlockType(
                                             currentLocation.getBlockX(),
@@ -225,7 +247,7 @@ public class HeatRayBrush extends AbstractBrush {
                                             BlockTypes.FIRE
                                     );
                                 }
-                            } else if (airDensity >= REQUIRED_AIR_DENSITY) {
+                            } else if (airDensity >= this.requiredAirDensity) {
                                 setBlockType(
                                         currentLocation.getBlockX(),
                                         currentLocation.getBlockY(),

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/JockeyBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/JockeyBrush.java
@@ -157,7 +157,7 @@ public class JockeyBrush extends AbstractBrush {
                         finalClosest.addPassenger(player);
                         jockeyedEntity = finalClosest;
                     }
-                    player.sendMessage(ChatColor.GREEN + "You are now saddles on entity: " + finalClosest.getEntityId());
+                    player.sendMessage(ChatColor.GREEN + "You are now sitting on entity: " + finalClosest.getEntityId());
                 }
             });
         } else {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/JockeyBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/JockeyBrush.java
@@ -23,9 +23,21 @@ import java.util.stream.Stream;
 public class JockeyBrush extends AbstractBrush {
 
     private static final int ENTITY_STACK_LIMIT = 50;
-    private JockeyType jockeyType = JockeyType.NORMAL_ALL_ENTITIES;
+
+    private static final JockeyType DEFAULT_JOCKEY_TYPE = JockeyType.NORMAL_ALL_ENTITIES;
+
     @Nullable
     private Entity jockeyedEntity;
+
+    private int entityStackLimit;
+
+    private JockeyType jockeyType;
+
+    @Override
+    public void loadProperties() {
+        this.entityStackLimit = getIntegerProperty("entity-stack-limit", ENTITY_STACK_LIMIT);
+        this.jockeyType = (JockeyType) getEnumProperty("default-jockey-type", JockeyType.class, DEFAULT_JOCKEY_TYPE);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
@@ -162,7 +174,7 @@ public class JockeyBrush extends AbstractBrush {
         Entity lastEntity = player;
         int stackHeight = 0;
         for (Entity entity : nearbyEntities) {
-            if (stackHeight >= ENTITY_STACK_LIMIT) {
+            if (stackHeight >= entityStackLimit) {
                 return;
             }
             if (this.jockeyType == JockeyType.STACK_ALL_ENTITIES) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/MoveBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/MoveBrush.java
@@ -193,6 +193,11 @@ public class MoveBrush extends AbstractBrush {
         private BlockVector3 location2;
         private World world2;
 
+        /**
+         * Create a new limited selection.
+         *
+         * @param maxBlockCount maximum number of blocks allowed inside
+         */
         public Selection(int maxBlockCount) {
             this.maxBlockCount = maxBlockCount;
         }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/OceanBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/OceanBrush.java
@@ -22,7 +22,7 @@ public class OceanBrush extends AbstractBrush {
     private static final int WATER_LEVEL_MIN = 12;
     private static final int LOW_CUT_LEVEL = 12;
 
-    private static final int DEFAULT_WATER_LEVEL = 62; // y=63 -- We are using array indices here.
+    private static final int DEFAULT_WATER_LEVEL = 63;
 
     private static final MaterialSet EXCLUDED_MATERIALS = MaterialSet.builder()
             .with(BlockCategories.SAPLINGS)
@@ -65,16 +65,16 @@ public class OceanBrush extends AbstractBrush {
             messenger.sendMessage(ChatColor.BLUE + "Parameters:");
             messenger.sendMessage(ChatColor.GREEN + "/b o wlevel [n] " + ChatColor.BLUE + "-- Sets the water level to n.");
             messenger.sendMessage(ChatColor.GREEN + "/b o cfloor [true|false] " + ChatColor.BLUE + "-- Enables or disables " +
-                    "sea floor cover. (e.g. -cfloor y) (Cover material will be your voxel material)");
+                    "sea floor cover. (e.g. -cfloor true -> Cover material will be your voxel material)");
         } else {
             if (parameters.length == 2) {
                 if (firstParameter.equalsIgnoreCase("wlevel")) {
                     Integer waterLevel = NumericParser.parseInteger(parameters[1]);
                     if (waterLevel != null && waterLevel > this.waterLevelMin) {
-                        this.waterLevel = waterLevel - 1;
-                        messenger.sendMessage(ChatColor.BLUE + "Water level set to " + ChatColor.GREEN + (this.waterLevel + 1)); // +1 since we are working with 0-based array indices
+                        this.waterLevel = waterLevel;
+                        messenger.sendMessage(ChatColor.BLUE + "Water level set to: " + ChatColor.GREEN + this.waterLevel);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number, must be an integer greater " + this.waterLevelMin + ".");
                     }
                 } else if (firstParameter.equalsIgnoreCase("cfloor")) {
                     this.coverFloor = Boolean.parseBoolean(parameters[1]);
@@ -130,7 +130,7 @@ public class OceanBrush extends AbstractBrush {
         for (int x = minX; x <= maxX; x++) {
             for (int z = minZ; z <= maxZ; z++) {
                 int currentHeight = getHeight(x, z);
-                int wLevelDiff = currentHeight - (this.waterLevel - 1);
+                int wLevelDiff = currentHeight - this.waterLevel;
                 int newSeaFloorLevel = Math.max((this.waterLevel - wLevelDiff), this.lowCutLevel);
                 int highestY = getHighestTerrainBlock(x, z, editSession.getMinY(), editSession.getMaxY());
                 // go down from highest Y block down to new sea floor
@@ -141,7 +141,7 @@ public class OceanBrush extends AbstractBrush {
                     }
                 }
                 // go down from water level to new sea level
-                for (int y = this.waterLevel; y > newSeaFloorLevel; y--) {
+                for (int y = this.waterLevel; y >= newSeaFloorLevel; y--) {
                     BlockState block = getBlock(x, y, z);
                     BlockType blockType = block.getBlockType();
                     if (blockType != BlockTypes.WATER) {
@@ -149,7 +149,7 @@ public class OceanBrush extends AbstractBrush {
                     }
                 }
                 // cover the sea floor of required
-                if (this.coverFloor && (newSeaFloorLevel < this.waterLevel)) {
+                if (this.coverFloor && (newSeaFloorLevel <= this.waterLevel)) {
                     BlockState block = getBlock(x, newSeaFloorLevel, z);
                     BlockType blockType = block.getBlockType();
                     if (blockType != toolkitProperties.getBlockType()) {
@@ -180,7 +180,7 @@ public class OceanBrush extends AbstractBrush {
     public void sendInfo(Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
         messenger.sendBrushNameMessage();
-        messenger.sendMessage(ChatColor.BLUE + "Water level set to " + ChatColor.GREEN + (this.waterLevel + 1)); // +1 since we are working with 0-based array indices
+        messenger.sendMessage(ChatColor.BLUE + "Water level set to: " + ChatColor.GREEN + this.waterLevel);
         messenger.sendMessage(ChatColor.BLUE + String.format(
                 "Floor cover %s.",
                 ChatColor.GREEN + (this.coverFloor ? "enabled" : "disabled")

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/OceanBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/OceanBrush.java
@@ -74,7 +74,8 @@ public class OceanBrush extends AbstractBrush {
                         this.waterLevel = waterLevel;
                         messenger.sendMessage(ChatColor.BLUE + "Water level set to: " + ChatColor.GREEN + this.waterLevel);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number, must be an integer >" + this.waterLevelMin + ".");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number, must be an integer greater than" +
+                                this.waterLevelMin + ".");
                     }
                 } else if (firstParameter.equalsIgnoreCase("cfloor")) {
                     this.coverFloor = Boolean.parseBoolean(parameters[1]);

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/OceanBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/OceanBrush.java
@@ -65,7 +65,7 @@ public class OceanBrush extends AbstractBrush {
             messenger.sendMessage(ChatColor.BLUE + "Parameters:");
             messenger.sendMessage(ChatColor.GREEN + "/b o wlevel [n] " + ChatColor.BLUE + "-- Sets the water level to n.");
             messenger.sendMessage(ChatColor.GREEN + "/b o cfloor [true|false] " + ChatColor.BLUE + "-- Enables or disables " +
-                    "sea floor cover. (e.g. -cfloor true -> Cover material will be your voxel material)");
+                    "sea floor cover. (e.g. /b o cfloor true -> Cover material will be your voxel material.)");
         } else {
             if (parameters.length == 2) {
                 if (firstParameter.equalsIgnoreCase("wlevel")) {
@@ -74,7 +74,7 @@ public class OceanBrush extends AbstractBrush {
                         this.waterLevel = waterLevel;
                         messenger.sendMessage(ChatColor.BLUE + "Water level set to: " + ChatColor.GREEN + this.waterLevel);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number, must be an integer greater " + this.waterLevelMin + ".");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number, must be an integer >" + this.waterLevelMin + ".");
                     }
                 } else if (firstParameter.equalsIgnoreCase("cfloor")) {
                     this.coverFloor = Boolean.parseBoolean(parameters[1]);

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/OceanBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/OceanBrush.java
@@ -119,7 +119,7 @@ public class OceanBrush extends AbstractBrush {
                 int currentHeight = getHeight(x, z);
                 int wLevelDiff = currentHeight - (this.waterLevel - 1);
                 int newSeaFloorLevel = Math.max((this.waterLevel - wLevelDiff), LOW_CUT_LEVEL);
-                int highestY = getHighestTerrainBlock(x, z, editSession.getMinY(), editSession.getMaxY() + 1);
+                int highestY = getHighestTerrainBlock(x, z, editSession.getMinY(), editSession.getMaxY());
                 // go down from highest Y block down to new sea floor
                 for (int y = highestY; y > newSeaFloorLevel; y--) {
                     BlockState block = getBlock(x, y, z);
@@ -149,7 +149,12 @@ public class OceanBrush extends AbstractBrush {
 
     private int getHeight(int bx, int bz) {
         EditSession editSession = getEditSession();
-        for (int y = getHighestTerrainBlock(bx, bz, editSession.getMinY(), editSession.getMaxY() + 1); y > 0; y--) {
+        for (int y = getHighestTerrainBlock(
+                bx,
+                bz,
+                editSession.getMinY(),
+                editSession.getMaxY()
+        ); y > editSession.getMinY(); y--) {
             BlockState clamp = this.clampY(bx, y, bz);
             if (!EXCLUDED_MATERIALS.contains(clamp)) {
                 return y;

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/OceanBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/OceanBrush.java
@@ -19,9 +19,11 @@ import java.util.stream.Stream;
 
 public class OceanBrush extends AbstractBrush {
 
-    private static final int WATER_LEVEL_DEFAULT = 62; // y=63 -- we are using array indices here
     private static final int WATER_LEVEL_MIN = 12;
     private static final int LOW_CUT_LEVEL = 12;
+
+    private static final int DEFAULT_WATER_LEVEL = 62; // y=63 -- We are using array indices here.
+
     private static final MaterialSet EXCLUDED_MATERIALS = MaterialSet.builder()
             .with(BlockCategories.SAPLINGS)
             .with(BlockCategories.LOGS)
@@ -40,8 +42,19 @@ public class OceanBrush extends AbstractBrush {
             .add(BlockTypes.TALL_GRASS)
             .build();
 
-    private int waterLevel = WATER_LEVEL_DEFAULT;
+    private int waterLevelMin;
+    private int lowCutLevel;
+
+    private int waterLevel;
     private boolean coverFloor;
+
+    @Override
+    public void loadProperties() {
+        this.waterLevelMin = getIntegerProperty("water-level-min", WATER_LEVEL_MIN);
+        this.lowCutLevel = getIntegerProperty("low-cut-level", LOW_CUT_LEVEL);
+
+        this.waterLevel = getIntegerProperty("default-water-lever", DEFAULT_WATER_LEVEL);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
@@ -57,7 +70,7 @@ public class OceanBrush extends AbstractBrush {
             if (parameters.length == 2) {
                 if (firstParameter.equalsIgnoreCase("wlevel")) {
                     Integer waterLevel = NumericParser.parseInteger(parameters[1]);
-                    if (waterLevel != null && waterLevel > WATER_LEVEL_MIN) {
+                    if (waterLevel != null && waterLevel > this.waterLevelMin) {
                         this.waterLevel = waterLevel - 1;
                         messenger.sendMessage(ChatColor.BLUE + "Water level set to " + ChatColor.GREEN + (this.waterLevel + 1)); // +1 since we are working with 0-based array indices
                     } else {
@@ -118,7 +131,7 @@ public class OceanBrush extends AbstractBrush {
             for (int z = minZ; z <= maxZ; z++) {
                 int currentHeight = getHeight(x, z);
                 int wLevelDiff = currentHeight - (this.waterLevel - 1);
-                int newSeaFloorLevel = Math.max((this.waterLevel - wLevelDiff), LOW_CUT_LEVEL);
+                int newSeaFloorLevel = Math.max((this.waterLevel - wLevelDiff), this.lowCutLevel);
                 int highestY = getHighestTerrainBlock(x, z, editSession.getMinY(), editSession.getMaxY());
                 // go down from highest Y block down to new sea floor
                 for (int y = highestY; y > newSeaFloorLevel; y--) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/PullBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/PullBrush.java
@@ -16,10 +16,20 @@ import java.util.Set;
 
 public class PullBrush extends AbstractBrush {
 
+    private static final int DEFAULT_PINCH = 1;
+    private static final int DEFAULT_BUBBLE = 0;
+
     private final Set<PullBrushBlockWrapper> surface = new HashSet<>();
     private int voxelHeight;
-    private double pinch = 1;
+
+    private double pinch;
     private double bubble;
+
+    @Override
+    public void loadProperties() {
+        this.pinch = getIntegerProperty("default-pinch", DEFAULT_PINCH);
+        this.bubble = getIntegerProperty("default-bubble", DEFAULT_BUBBLE);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/RandomErodeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/RandomErodeBrush.java
@@ -14,13 +14,14 @@ import java.util.Random;
 public class RandomErodeBrush extends AbstractBrush {
 
     private static final double TRUE_CIRCLE = 0.5;
+
     private final Random generator = new Random();
     private BlockWrapper[][][] snap;
     private int brushSize;
     private int erodeFace;
     private int fillFace;
-    private int erodeRecursion = 1;
-    private int fillRecursion = 1;
+    private int erodeRecursion;
+    private int fillRecursion;
 
     @Override
     public void handleArrowAction(Snipe snipe) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/RegenerateChunkBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/RegenerateChunkBrush.java
@@ -60,7 +60,7 @@ public class RegenerateChunkBrush extends AbstractBrush {
                             messenger.sendMessage(ChatColor.RED + "Invalid biome type.");
                         }
                     }
-                    messenger.sendMessage(ChatColor.GOLD + "Biome type set to " + ChatColor.DARK_GREEN +
+                    messenger.sendMessage(ChatColor.GOLD + "Biome type set to: " + ChatColor.DARK_GREEN +
                             (this.biomeType == null ? DEFAULT_BIOME : this.biomeType.getId()));
                 }
             } else {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/RegenerateChunkBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/RegenerateChunkBrush.java
@@ -44,7 +44,9 @@ public class RegenerateChunkBrush extends AbstractBrush {
                                     BiomeTypes.values().stream()
                                             .map(biomeType -> ((biomeType == this.biomeType) ? ChatColor.GOLD : ChatColor.GRAY) +
                                                     biomeType.getId().substring(Identifiers.MINECRAFT_IDENTIFIER_LENGTH))
-                            ).collect(Collectors.joining(ChatColor.WHITE + ", "))
+                            ).collect(Collectors.joining(ChatColor.WHITE + ", ",
+                                    ChatColor.AQUA + "Available biomes: ", ""
+                            ))
                     );
                 } else {
                     if (firstParameter.equals(DEFAULT_BIOME)) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/RegenerateChunkBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/RegenerateChunkBrush.java
@@ -18,6 +18,7 @@ import java.util.stream.Stream;
 public class RegenerateChunkBrush extends AbstractBrush {
 
     private static final String DEFAULT_BIOME = "default";
+
     private static final List<String> BIOMES = BiomeTypes.values().stream()
             .map(biomeType -> biomeType.getId().substring(Identifiers.MINECRAFT_IDENTIFIER_LENGTH))
             .collect(Collectors.toList());

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/RulerBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/RulerBrush.java
@@ -5,10 +5,8 @@ import com.sk89q.worldedit.world.block.BlockType;
 import com.thevoxelbox.voxelsniper.sniper.snipe.Snipe;
 import com.thevoxelbox.voxelsniper.sniper.snipe.message.SnipeMessenger;
 import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
-import com.thevoxelbox.voxelsniper.util.Vectors;
 import com.thevoxelbox.voxelsniper.util.text.NumericParser;
 import org.bukkit.ChatColor;
-import org.bukkit.util.Vector;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -16,7 +14,7 @@ import java.util.stream.Stream;
 public class RulerBrush extends AbstractBrush {
 
     private boolean first = true;
-    private Vector coordinates = new Vector(0, 0, 0);
+    private BlockVector3 coordinates = BlockVector3.ZERO;
     private int offsetX;
     private int offsetY;
     private int offsetZ;
@@ -78,7 +76,7 @@ public class RulerBrush extends AbstractBrush {
         ToolkitProperties toolkitProperties = snipe.getToolkitProperties();
         BlockType blockDataType = toolkitProperties.getBlockType();
         BlockVector3 targetBlock = getTargetBlock();
-        this.coordinates = Vectors.toBukkit(targetBlock);
+        this.coordinates = targetBlock;
         if (this.offsetX == 0 && this.offsetY == 0 && this.offsetZ == 0) {
             SnipeMessenger messenger = snipe.createMessenger();
             messenger.sendMessage(ChatColor.DARK_PURPLE + "First point selected.");
@@ -94,7 +92,7 @@ public class RulerBrush extends AbstractBrush {
     @Override
     public void handleGunpowderAction(Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
-        if (this.coordinates == null || this.coordinates.lengthSquared() == 0) {
+        if (this.coordinates == null || this.coordinates.lengthSq() == 0) {
             messenger.sendMessage(ChatColor.RED + "Warning: You did not select a first coordinate with the arrow. Comparing to point 0,0,0 instead.");
             return;
         }
@@ -103,7 +101,7 @@ public class RulerBrush extends AbstractBrush {
         messenger.sendMessage(ChatColor.AQUA + "X change: " + (targetBlock.getX() - this.coordinates.getX()));
         messenger.sendMessage(ChatColor.AQUA + "Y change: " + (targetBlock.getY() - this.coordinates.getY()));
         messenger.sendMessage(ChatColor.AQUA + "Z change: " + (targetBlock.getZ() - this.coordinates.getZ()));
-        double distance = Math.round(Vectors.toBukkit(targetBlock)
+        double distance = Math.round(targetBlock
                 .subtract(this.coordinates)
                 .length() * 100) / 100.0;
         double blockDistance = Math.round((Math.abs(Math.max(Math.max(

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/RulerBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/RulerBrush.java
@@ -13,11 +13,16 @@ import java.util.stream.Stream;
 
 public class RulerBrush extends AbstractBrush {
 
+    private static final int DEFAULT_X_OFFSET = 0;
+    private static final int DEFAULT_Y_OFFSET = 0;
+    private static final int DEFAULT_Z_OFFSET = 0;
+
     private boolean first = true;
     private BlockVector3 coordinates = BlockVector3.ZERO;
-    private int offsetX;
-    private int offsetY;
-    private int offsetZ;
+
+    private int xOffset = DEFAULT_X_OFFSET;
+    private int yOffset = DEFAULT_Y_OFFSET;
+    private int zOffset = DEFAULT_Z_OFFSET;
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
@@ -37,24 +42,24 @@ public class RulerBrush extends AbstractBrush {
         } else {
             if (parameters.length == 1) {
                 if (firstParameter.equalsIgnoreCase("ruler")) {
-                    this.offsetZ = 0;
-                    this.offsetY = 0;
-                    this.offsetX = 0;
+                    this.zOffset = 0;
+                    this.yOffset = 0;
+                    this.xOffset = 0;
                     messenger.sendMessage(ChatColor.BLUE + "Ruler mode.");
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid brush parameters! Use the \"info\" parameter to display " +
                             "parameter info.");
                 }
             } else if (parameters.length == 3) {
-                Integer offsetX = NumericParser.parseInteger(parameters[0]);
-                Integer offsetY = NumericParser.parseInteger(parameters[1]);
-                Integer offsetZ = NumericParser.parseInteger(parameters[2]);
-                this.offsetX = offsetX == null ? 0 : offsetX;
-                this.offsetY = offsetY == null ? 0 : offsetY;
-                this.offsetZ = offsetZ == null ? 0 : offsetZ;
-                messenger.sendMessage(ChatColor.AQUA + "X offset set to: " + this.offsetX);
-                messenger.sendMessage(ChatColor.AQUA + "Y offset set to: " + this.offsetY);
-                messenger.sendMessage(ChatColor.AQUA + "Z offset set to: " + this.offsetZ);
+                Integer xOffset = NumericParser.parseInteger(parameters[0]);
+                Integer yOffset = NumericParser.parseInteger(parameters[1]);
+                Integer zOffset = NumericParser.parseInteger(parameters[2]);
+                this.xOffset = xOffset == null ? 0 : xOffset;
+                this.yOffset = yOffset == null ? 0 : yOffset;
+                this.zOffset = zOffset == null ? 0 : zOffset;
+                messenger.sendMessage(ChatColor.AQUA + "X-Offset set to: " + this.xOffset);
+                messenger.sendMessage(ChatColor.AQUA + "Y-Offset set to: " + this.yOffset);
+                messenger.sendMessage(ChatColor.AQUA + "Z-Offset set to: " + this.zOffset);
             } else {
                 messenger.sendMessage(ChatColor.RED + "Invalid brush parameters length! Use the \"info\" parameter to display " +
                         "parameter info.");
@@ -77,7 +82,7 @@ public class RulerBrush extends AbstractBrush {
         BlockType blockDataType = toolkitProperties.getBlockType();
         BlockVector3 targetBlock = getTargetBlock();
         this.coordinates = targetBlock;
-        if (this.offsetX == 0 && this.offsetY == 0 && this.offsetZ == 0) {
+        if (this.xOffset == 0 && this.yOffset == 0 && this.zOffset == 0) {
             SnipeMessenger messenger = snipe.createMessenger();
             messenger.sendMessage(ChatColor.DARK_PURPLE + "First point selected.");
             this.first = !this.first;
@@ -85,7 +90,7 @@ public class RulerBrush extends AbstractBrush {
             int x = targetBlock.getX();
             int y = targetBlock.getY();
             int z = targetBlock.getZ();
-            setBlockType(x + this.offsetX, y + this.offsetY, z + this.offsetZ, blockDataType);
+            setBlockType(x + this.xOffset, y + this.yOffset, z + this.zOffset, blockDataType);
         }
     }
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ScannerBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ScannerBrush.java
@@ -48,7 +48,7 @@ public class ScannerBrush extends AbstractBrush {
                     Integer depth = NumericParser.parseInteger(parameters[1]);
                     if (depth != null) {
                         this.depth = depth < this.depthMin ? this.depthMin : Math.min(depth, this.depthMax);
-                        messenger.sendMessage(ChatColor.AQUA + "Scanner depth set to " + this.depth);
+                        messenger.sendMessage(ChatColor.AQUA + "Scanner depth set to: " + this.depth);
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");
                     }
@@ -100,41 +100,41 @@ public class ScannerBrush extends AbstractBrush {
     private void scan(Snipe snipe, Direction blockFace) {
         SnipeMessenger messenger = snipe.createMessenger();
         BlockVector3 targetBlock = getTargetBlock();
-        if (blockFace == Direction.NORTH) {// Scan south
-            for (int i = 1; i < this.depth + 1; i++) {
-                if (getBlockType(targetBlock.getX() + i, clampY(targetBlock.getY()), targetBlock.getZ()) == this.checkFor) {
-                    messenger.sendMessage(ChatColor.GREEN + String.valueOf(this.checkFor) + " found after " + i + " blocks.");
-                    return;
-                }
-            }
-            messenger.sendMessage(ChatColor.GRAY + "Nope.");
-        } else if (blockFace == Direction.SOUTH) {// Scan north
-            for (int i = 1; i < this.depth + 1; i++) {
-                if (getBlockType(targetBlock.getX() - i, clampY(targetBlock.getY()), targetBlock.getZ()) == this.checkFor) {
-                    messenger.sendMessage(ChatColor.GREEN + String.valueOf(this.checkFor) + " found after " + i + " blocks.");
-                    return;
-                }
-            }
-            messenger.sendMessage(ChatColor.GRAY + "Nope.");
-        } else if (blockFace == Direction.EAST) {// Scan west
+        if (blockFace == Direction.NORTH) { // Scan south
             for (int i = 1; i < this.depth + 1; i++) {
                 if (getBlockType(targetBlock.getX(), clampY(targetBlock.getY()), targetBlock.getZ() + i) == this.checkFor) {
                     messenger.sendMessage(ChatColor.GREEN + String.valueOf(this.checkFor) + " found after " + i + " blocks.");
                     return;
                 }
             }
-            messenger.sendMessage(ChatColor.GRAY + "Nope.");
-        } else if (blockFace == Direction.WEST) {// Scan east
+            messenger.sendMessage(ChatColor.GRAY + "No matching block found.");
+        } else if (blockFace == Direction.SOUTH) { // Scan north
             for (int i = 1; i < this.depth + 1; i++) {
                 if (getBlockType(targetBlock.getX(), clampY(targetBlock.getY()), targetBlock.getZ() - i) == this.checkFor) {
                     messenger.sendMessage(ChatColor.GREEN + String.valueOf(this.checkFor) + " found after " + i + " blocks.");
                     return;
                 }
             }
-            messenger.sendMessage(ChatColor.GRAY + "Nope.");
-        } else if (blockFace == Direction.UP) {// Scan down
+            messenger.sendMessage(ChatColor.GRAY + "No matching block found.");
+        } else if (blockFace == Direction.EAST) { // Scan west
             for (int i = 1; i < this.depth + 1; i++) {
-                if ((targetBlock.getY() - i) <= 0) {
+                if (getBlockType(targetBlock.getX() - i, clampY(targetBlock.getY()), targetBlock.getZ()) == this.checkFor) {
+                    messenger.sendMessage(ChatColor.GREEN + String.valueOf(this.checkFor) + " found after " + i + " blocks.");
+                    return;
+                }
+            }
+            messenger.sendMessage(ChatColor.GRAY + "No matching block found.");
+        } else if (blockFace == Direction.WEST) { // Scan east
+            for (int i = 1; i < this.depth + 1; i++) {
+                if (getBlockType(targetBlock.getX() + i, clampY(targetBlock.getY()), targetBlock.getZ()) == this.checkFor) {
+                    messenger.sendMessage(ChatColor.GREEN + String.valueOf(this.checkFor) + " found after " + i + " blocks.");
+                    return;
+                }
+            }
+            messenger.sendMessage(ChatColor.GRAY + "No matching block found.");
+        } else if (blockFace == Direction.UP) { // Scan down
+            for (int i = 1; i < this.depth + 1; i++) {
+                if ((targetBlock.getY() - i) <= getEditSession().getMinY()) {
                     break;
                 }
                 if (getBlockType(targetBlock.getX(), clampY(targetBlock.getY() - i), targetBlock.getZ()) == this.checkFor) {
@@ -142,8 +142,8 @@ public class ScannerBrush extends AbstractBrush {
                     return;
                 }
             }
-            messenger.sendMessage(ChatColor.GRAY + "Nope.");
-        } else if (blockFace == Direction.DOWN) {// Scan up
+            messenger.sendMessage(ChatColor.GRAY + "No matching block found.");
+        } else if (blockFace == Direction.DOWN) { // Scan up
             for (int i = 1; i < this.depth + 1; i++) {
                 EditSession editSession = getEditSession();
                 if ((targetBlock.getY() + i) >= editSession.getMaxY()) {
@@ -154,7 +154,7 @@ public class ScannerBrush extends AbstractBrush {
                     return;
                 }
             }
-            messenger.sendMessage(ChatColor.GRAY + "Nope.");
+            messenger.sendMessage(ChatColor.GRAY + "No matching block found.");
         }
     }
 
@@ -162,7 +162,7 @@ public class ScannerBrush extends AbstractBrush {
     public void sendInfo(Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
         messenger.sendBrushNameMessage();
-        messenger.sendMessage(ChatColor.GREEN + "Scanner depth set to " + this.depth);
+        messenger.sendMessage(ChatColor.GREEN + "Scanner depth set to: " + this.depth);
         messenger.sendMessage(ChatColor.GREEN + "Scanner scans for " + this.checkFor + " (change with /v #)");
     }
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ScannerBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ScannerBrush.java
@@ -135,7 +135,7 @@ public class ScannerBrush extends AbstractBrush {
         } else if (blockFace == Direction.DOWN) {// Scan up
             for (int i = 1; i < this.depth + 1; i++) {
                 EditSession editSession = getEditSession();
-                if ((targetBlock.getY() + i) >= editSession.getMaxY() + 1) {
+                if ((targetBlock.getY() + i) >= editSession.getMaxY()) {
                     break;
                 }
                 if (getBlockType(targetBlock.getX(), clampY(targetBlock.getY() + i), targetBlock.getZ()) == this.checkFor) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ScannerBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ScannerBrush.java
@@ -4,7 +4,6 @@ import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.world.block.BlockType;
-import com.sk89q.worldedit.world.block.BlockTypes;
 import com.thevoxelbox.voxelsniper.sniper.snipe.Snipe;
 import com.thevoxelbox.voxelsniper.sniper.snipe.message.SnipeMessenger;
 import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
@@ -17,11 +16,23 @@ import java.util.stream.Stream;
 public class ScannerBrush extends AbstractBrush {
 
     private static final int DEPTH_MIN = 1;
-    private static final int DEPTH_DEFAULT = 24;
     private static final int DEPTH_MAX = 64;
 
-    private int depth = DEPTH_DEFAULT;
-    private BlockType checkFor = BlockTypes.AIR;
+    private static final int DEFAULT_DEPTH = 24;
+
+    private int depthMin;
+    private int depthMax;
+
+    private int depth;
+    private BlockType checkFor;
+
+    @Override
+    public void loadProperties() {
+        this.depthMin = getIntegerProperty("depth-min", DEPTH_MIN);
+        this.depthMax = getIntegerProperty("depth-max", DEPTH_MAX);
+
+        this.depth = getIntegerProperty("default-depth", DEFAULT_DEPTH);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
@@ -36,7 +47,7 @@ public class ScannerBrush extends AbstractBrush {
                 if (firstParameter.equalsIgnoreCase("d")) {
                     Integer depth = NumericParser.parseInteger(parameters[1]);
                     if (depth != null) {
-                        this.depth = depth < DEPTH_MIN ? DEPTH_MIN : Math.min(depth, DEPTH_MAX);
+                        this.depth = depth < this.depthMin ? this.depthMin : Math.min(depth, this.depthMax);
                         messenger.sendMessage(ChatColor.AQUA + "Scanner depth set to " + this.depth);
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/SignOverwriteBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/SignOverwriteBrush.java
@@ -27,15 +27,19 @@ public class SignOverwriteBrush extends AbstractBrush {
     private static final int MAX_SIGN_LINE_LENGTH = 15;
     private static final int NUM_SIGN_LINES = 4;
 
-    private final File pluginDataFolder;
     private final String[] signTextLines = new String[NUM_SIGN_LINES];
     private final boolean[] signLinesEnabled = new boolean[]{true, true, true, true};
     private boolean rangedMode;
 
-    public SignOverwriteBrush(File pluginDataFolder) {
-        this.pluginDataFolder = pluginDataFolder;
+    public SignOverwriteBrush() {
         clearBuffer();
         resetStates();
+    }
+
+    @Override
+    public void loadProperties() {
+        File dataFolder = new File(PLUGIN_DATA_FOLDER, "/signs");
+        dataFolder.mkdirs();
     }
 
     @Override
@@ -277,7 +281,7 @@ public class SignOverwriteBrush extends AbstractBrush {
      */
     private void saveBufferToFile(Snipe snipe, String fileName) {
         SnipeMessenger messenger = snipe.createMessenger();
-        File store = new File(this.pluginDataFolder, "/signs/" + fileName + ".vsign");
+        File store = new File(PLUGIN_DATA_FOLDER, "/signs/" + fileName + ".vsign");
         if (store.exists()) {
             messenger.sendMessage(ChatColor.RED + "This file already exists.");
             return;
@@ -302,11 +306,11 @@ public class SignOverwriteBrush extends AbstractBrush {
     /**
      * Loads a buffer from a file.
      *
-     * @return true if file has been loaded successfully, false otherwise
+     * @return {@code true} if file has been loaded successfully, {@code false} otherwise
      */
     private boolean loadBufferFromFile(Snipe snipe, String fileName) {
         SnipeMessenger messenger = snipe.createMessenger();
-        File store = new File(this.pluginDataFolder, "/signs/" + fileName + ".vsign");
+        File store = new File(PLUGIN_DATA_FOLDER, "/signs/" + fileName + ".vsign");
         if (!store.exists()) {
             messenger.sendMessage(ChatColor.RED + "This file does not exist.");
             return false;

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/SpiralStaircaseBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/SpiralStaircaseBrush.java
@@ -19,9 +19,20 @@ import java.util.stream.Stream;
 // TODO rewrite to accept all stairs and steps.
 public class SpiralStaircaseBrush extends AbstractBrush {
 
-    private String stairType = "block"; // "block" 1x1 blocks (default), "step" alternating step double step, "stair" staircase with blocks on corners
-    private String sdirect = "c"; // "c" clockwise (default), "cc" counter-clockwise
-    private String sopen = "n"; // "n" north (default), "e" east, "world" south, "world" west
+    private static final String DEFAULT_STAIR_TYPE = "block";
+    private static final String DEFAULT_SDIRECT = "c";
+    private static final String DEFAULT_SOPEN = "n";
+
+    private String stairType; // "block" 1x1 blocks (default), "step" alternating step double step, "stair" staircase with blocks on corners
+    private String sdirect; // "c" clockwise (default), "cc" counter-clockwise
+    private String sopen; // "n" north (default), "e" east, "world" south, "world" west
+
+    @Override
+    public void loadProperties() {
+        this.stairType = getStringProperty("default-stair-type", DEFAULT_STAIR_TYPE);
+        this.sdirect = getStringProperty("default-sdirect", DEFAULT_SDIRECT);
+        this.sopen = getStringProperty("default-sopen", DEFAULT_SOPEN);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/SpiralStaircaseBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/SpiralStaircaseBrush.java
@@ -15,8 +15,6 @@ import org.bukkit.ChatColor;
 import java.util.List;
 import java.util.stream.Stream;
 
-// TODO maybe add an arg to pass the width of the staircase, voxel height is the default implemented arg for several brushes.
-// TODO rewrite to accept all stairs and steps.
 public class SpiralStaircaseBrush extends AbstractBrush {
 
     private static final String DEFAULT_STAIR_TYPE = "block";

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/TreeSnipeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/TreeSnipeBrush.java
@@ -39,7 +39,9 @@ public class TreeSnipeBrush extends AbstractBrush {
                             Arrays.stream(TreeGenerator.TreeType.values())
                                     .map(treeType -> ((treeType == this.treeType) ? ChatColor.GOLD : ChatColor.GRAY) +
                                             treeType.lookupKeys.get(0))
-                                    .collect(Collectors.joining(ChatColor.WHITE + ", "))
+                                    .collect(Collectors.joining(ChatColor.WHITE + ", ",
+                                            ChatColor.AQUA + "Available tree types: ", ""
+                                    ))
                     );
                 } else {
                     TreeGenerator.TreeType treeType = TreeGenerator.TreeType.lookup(firstParameter);

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/TreeSnipeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/TreeSnipeBrush.java
@@ -19,9 +19,18 @@ import java.util.stream.Stream;
 
 public class TreeSnipeBrush extends AbstractBrush {
 
+    private static final TreeGenerator.TreeType DEFAULT_TREE_TYPE = TreeGenerator.TreeType.TREE;
+
     private static final List<String> TREES = new ArrayList<>(TreeGenerator.TreeType.getPrimaryAliases());
 
-    private TreeGenerator.TreeType treeType = TreeGenerator.TreeType.TREE;
+    private TreeGenerator.TreeType treeType;
+
+    @Override
+    public void loadProperties() {
+        this.treeType = (TreeGenerator.TreeType) getEnumProperty("default-tree-type", TreeGenerator.TreeType.class,
+                DEFAULT_TREE_TYPE
+        );
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/canyon/CanyonBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/canyon/CanyonBrush.java
@@ -17,7 +17,21 @@ public class CanyonBrush extends AbstractBrush {
 
     private static final int SHIFT_LEVEL_MIN = 10;
     private static final int SHIFT_LEVEL_MAX = 60;
-    private int yLevel = 10;
+
+    private static final int DEFAULT_Y_LEVEL = 10;
+
+    private int shiftLevelMin;
+    private int shiftLevelMax;
+
+    private int yLevel;
+
+    @Override
+    public void loadProperties() {
+        this.shiftLevelMin = getIntegerProperty("shift-level-min", SHIFT_LEVEL_MIN);
+        this.shiftLevelMax = getIntegerProperty("shift-level-max", SHIFT_LEVEL_MAX);
+
+        this.yLevel = getIntegerProperty("default-y-level", DEFAULT_Y_LEVEL);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
@@ -33,10 +47,10 @@ public class CanyonBrush extends AbstractBrush {
                 if (firstParameter.equalsIgnoreCase("y")) {
                     Integer yLevel = NumericParser.parseInteger(parameters[1]);
                     if (yLevel != null) {
-                        if (yLevel < SHIFT_LEVEL_MIN) {
-                            yLevel = SHIFT_LEVEL_MIN;
-                        } else if (yLevel > SHIFT_LEVEL_MAX) {
-                            yLevel = SHIFT_LEVEL_MAX;
+                        if (yLevel < this.shiftLevelMin) {
+                            yLevel = this.shiftLevelMin;
+                        } else if (yLevel > this.shiftLevelMax) {
+                            yLevel = this.shiftLevelMax;
                         }
                         this.yLevel = yLevel;
                         messenger.sendMessage(ChatColor.GREEN + "Shift Level set to: " + this.yLevel);
@@ -94,7 +108,7 @@ public class CanyonBrush extends AbstractBrush {
                     currentYLevel++;
                 }
                 setBlockType(blockX + x, 0, blockZ + z, BlockTypes.BEDROCK);
-                for (int y = 1; y < SHIFT_LEVEL_MIN; y++) {
+                for (int y = 1; y < this.shiftLevelMin; y++) {
                     setBlockType(blockX + x, y, blockZ + z, BlockTypes.STONE);
                 }
             }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/canyon/CanyonBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/canyon/CanyonBrush.java
@@ -87,7 +87,7 @@ public class CanyonBrush extends AbstractBrush {
         for (int x = 0; x < CHUNK_SIZE; x++) {
             for (int z = 0; z < CHUNK_SIZE; z++) {
                 int currentYLevel = this.yLevel;
-                for (int y = 63; y < editSession.getMaxY() + 1; y++) {
+                for (int y = 63; y <= editSession.getMaxY(); y++) {
                     BlockType blockType = getBlockType(blockX + x, y, blockZ + z);
                     setBlockType(blockX + x, currentYLevel, blockZ + z, blockType);
                     setBlockType(blockX + x, y, blockZ + z, BlockTypes.AIR);

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/canyon/CanyonBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/canyon/CanyonBrush.java
@@ -40,7 +40,8 @@ public class CanyonBrush extends AbstractBrush {
 
         if (firstParameter.equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.GOLD + "Canyon Brush Brush Parameters:");
-            messenger.sendMessage(ChatColor.AQUA + "/b ca y [n] -- Sets the Level to which the land will be shifted down to n.");
+            messenger.sendMessage(ChatColor.AQUA + "/b ca y [n] -- Sets the y-level to which the land will be shifted down to n" +
+                    ".");
         } else {
             if (parameters.length == 2) {
 
@@ -49,8 +50,10 @@ public class CanyonBrush extends AbstractBrush {
                     if (yLevel != null) {
                         if (yLevel < this.shiftLevelMin) {
                             yLevel = this.shiftLevelMin;
+                            messenger.sendMessage(ChatColor.RED + "Shift Level must be an integer >=" + this.shiftLevelMax + ".");
                         } else if (yLevel > this.shiftLevelMax) {
                             yLevel = this.shiftLevelMax;
+                            messenger.sendMessage(ChatColor.RED + "Shift Level must be an integer <=" + this.shiftLevelMin + ".");
                         }
                         this.yLevel = yLevel;
                         messenger.sendMessage(ChatColor.GREEN + "Shift Level set to: " + this.yLevel);

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/canyon/CanyonBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/canyon/CanyonBrush.java
@@ -50,10 +50,12 @@ public class CanyonBrush extends AbstractBrush {
                     if (yLevel != null) {
                         if (yLevel < this.shiftLevelMin) {
                             yLevel = this.shiftLevelMin;
-                            messenger.sendMessage(ChatColor.RED + "Shift Level must be an integer >=" + this.shiftLevelMax + ".");
+                            messenger.sendMessage(ChatColor.RED + "Shift Level must be an integer greater than or equal to" +
+                                    this.shiftLevelMax + ".");
                         } else if (yLevel > this.shiftLevelMax) {
                             yLevel = this.shiftLevelMax;
-                            messenger.sendMessage(ChatColor.RED + "Shift Level must be an integer <=" + this.shiftLevelMin + ".");
+                            messenger.sendMessage(ChatColor.RED + "Shift Level must be an integer less than or equal to " +
+                                    this.shiftLevelMin + ".");
                         }
                         this.yLevel = yLevel;
                         messenger.sendMessage(ChatColor.GREEN + "Shift Level set to: " + this.yLevel);

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/canyon/CanyonBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/canyon/CanyonBrush.java
@@ -15,10 +15,10 @@ import java.util.stream.Stream;
 
 public class CanyonBrush extends AbstractBrush {
 
-    private static final int SHIFT_LEVEL_MIN = 10;
+    private static final int SHIFT_LEVEL_MIN = -54;
     private static final int SHIFT_LEVEL_MAX = 60;
 
-    private static final int DEFAULT_Y_LEVEL = 10;
+    private static final int DEFAULT_Y_LEVEL = -54;
 
     private int shiftLevelMin;
     private int shiftLevelMax;
@@ -107,8 +107,8 @@ public class CanyonBrush extends AbstractBrush {
                     setBlockType(blockX + x, y, blockZ + z, BlockTypes.AIR);
                     currentYLevel++;
                 }
-                setBlockType(blockX + x, 0, blockZ + z, BlockTypes.BEDROCK);
-                for (int y = 1; y < this.shiftLevelMin; y++) {
+                setBlockType(blockX + x, editSession.getMinY(), blockZ + z, BlockTypes.BEDROCK);
+                for (int y = editSession.getMinY() + 1; y < this.shiftLevelMin; y++) {
                     setBlockType(blockX + x, y, blockZ + z, BlockTypes.STONE);
                 }
             }
@@ -119,7 +119,7 @@ public class CanyonBrush extends AbstractBrush {
     public void sendInfo(Snipe snipe) {
         snipe.createMessageSender()
                 .brushNameMessage()
-                .message(ChatColor.GREEN + "Shift Level set to " + this.yLevel)
+                .message(ChatColor.GREEN + "Shift Level set to: " + this.yLevel)
                 .send();
     }
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/canyon/CanyonSelectionBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/canyon/CanyonSelectionBrush.java
@@ -54,7 +54,7 @@ public class CanyonSelectionBrush extends CanyonBrush {
     public void sendInfo(Snipe snipe) {
         snipe.createMessageSender()
                 .brushNameMessage()
-                .message(ChatColor.GREEN + "Shift Level set to " + this.getYLevel())
+                .message(ChatColor.GREEN + "Shift Level set to: " + this.getYLevel())
                 .send();
     }
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityBrush.java
@@ -42,7 +42,9 @@ public class EntityBrush extends AbstractBrush {
                             EntityType.REGISTRY.values().stream()
                                     .map(entityType -> ((entityType == this.entityType) ? ChatColor.GOLD : ChatColor.GRAY) +
                                             entityType.getId().substring(Identifiers.MINECRAFT_IDENTIFIER_LENGTH))
-                                    .collect(Collectors.joining(ChatColor.WHITE + ", "))
+                                    .collect(Collectors.joining(ChatColor.WHITE + ", ",
+                                            ChatColor.AQUA + "Available entity types: ", ""
+                                    ))
                     );
                 } else {
                     EntityType currentEntity = EntityTypes.get(firstParameter);

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityBrush.java
@@ -20,11 +20,18 @@ import java.util.stream.Stream;
 
 public class EntityBrush extends AbstractBrush {
 
+    private static final EntityType DEFAULT_ENTITY_TYPE = EntityTypes.ZOMBIE;
+
     private static final List<String> ENTITIES = EntityType.REGISTRY.values().stream()
             .map(entityType -> entityType.getId().substring(Identifiers.MINECRAFT_IDENTIFIER_LENGTH))
             .collect(Collectors.toList());
 
-    private EntityType entityType = EntityTypes.ZOMBIE;
+    private EntityType entityType;
+
+    @Override
+    public void loadProperties() {
+        this.entityType = (EntityType) getRegistryProperty("default-entity-type", EntityType.REGISTRY, DEFAULT_ENTITY_TYPE);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityBrush.java
@@ -58,7 +58,7 @@ public class EntityBrush extends AbstractBrush {
 
                     if (currentEntity != null) {
                         this.entityType = currentEntity;
-                        messenger.sendMessage(ChatColor.GREEN + "Entity type set to " + ChatColor.DARK_GREEN + this.entityType.getName());
+                        messenger.sendMessage(ChatColor.GREEN + "Entity type set to: " + ChatColor.DARK_GREEN + this.entityType.getName());
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid entity type.");
                     }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityRemovalBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityRemovalBrush.java
@@ -65,7 +65,9 @@ public class EntityRemovalBrush extends AbstractBrush {
                     messenger.sendMessage(
                             exemptions.stream()
                                     .map(exemption -> ChatColor.LIGHT_PURPLE + exemption)
-                                    .collect(Collectors.joining(ChatColor.WHITE + ", "))
+                                    .collect(Collectors.joining(ChatColor.WHITE + ", ",
+                                            ChatColor.AQUA + "Available default exemptions: ", ""
+                                    ))
                     );
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid brush parameters! Use the \"info\" parameter to display " +
@@ -184,7 +186,11 @@ public class EntityRemovalBrush extends AbstractBrush {
     public void sendInfo(Snipe snipe) {
         snipe.createMessageSender()
                 .brushNameMessage()
-                .message(ChatColor.GREEN + "Exemptions: " + ChatColor.LIGHT_PURPLE + String.join(", ", this.exemptions))
+                .message(this.exemptions.stream()
+                        .map(exemption -> ChatColor.LIGHT_PURPLE + exemption)
+                        .collect(Collectors.joining(ChatColor.WHITE + ", ",
+                                ChatColor.GREEN + "Exemptions: ", ""
+                        )))
                 .brushSizeMessage()
                 .send();
     }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityRemovalBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityRemovalBrush.java
@@ -20,6 +20,10 @@ import java.util.stream.Stream;
 
 public class EntityRemovalBrush extends AbstractBrush {
 
+    private static final List<String> DEFAULT_EXEMPTIONS = Arrays.asList("org.bukkit.entity.Player",
+            "org.bukkit.entity.Hanging", "org.bukkit.entity.NPC"
+    );
+
     private static final List<String> ENTITY_CLASSES = Arrays.stream(EntityType.values())
             .map(EntityType::getEntityClass)
             .flatMap(entityClass -> getEntityClassHierarchy(entityClass).stream())
@@ -27,12 +31,14 @@ public class EntityRemovalBrush extends AbstractBrush {
             .map(Class::getCanonicalName)
             .collect(Collectors.toList());
 
-    private final List<String> exemptions = new ArrayList<>(3);
+    private List<String> exemptions;
 
-    public EntityRemovalBrush() {
-        this.exemptions.add("org.bukkit.entity.Player");
-        this.exemptions.add("org.bukkit.entity.Hanging");
-        this.exemptions.add("org.bukkit.entity.NPC");
+    @SuppressWarnings("unchecked")
+    @Override
+    public void loadProperties() {
+        this.exemptions = new ArrayList<>(
+                (List<String>) getListProperty("default-exemptions", DEFAULT_EXEMPTIONS)
+        );
     }
 
     private static List<Class<?>> getEntityClassHierarchy(Class<? extends Entity> entityClass) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/AbstractPerformerBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/AbstractPerformerBrush.java
@@ -11,16 +11,57 @@ import com.thevoxelbox.voxelsniper.sniper.snipe.Snipe;
 import com.thevoxelbox.voxelsniper.sniper.snipe.performer.PerformerSnipe;
 
 import java.util.Arrays;
+import java.util.Random;
 
 public abstract class AbstractPerformerBrush extends AbstractBrush implements PerformerBrush {
 
+    protected static final int SEED_PERCENT_MIN = 1;
+    protected static final int SEED_PERCENT_MAX = 9999;
+    protected static final int GROWTH_PERCENT_MIN = 1;
+    protected static final int GROWTH_PERCENT_MAX = 9999;
+    protected static final int SPLATTER_RECURSIONS_MIN = 1;
+    protected static final int SPLATTER_RECURSIONS_MAX = 10;
+
+    protected static final int DEFAULT_SEED_PERCENT = 1000;
+    protected static final int DEFAULT_GROWTH_PERCENT = 1000;
+    protected static final int DEFAULT_SPLATTER_RECURSIONS = 3;
+
+    protected final Random generator = new Random();
+
     protected Performer performer;
     private PerformerProperties performerProperties;
+
+    protected int seedPercentMin;
+    protected int seedPercentMax;
+    protected int growthPercentMin;
+    protected int growthPercentMax;
+    protected int splatterRecursionsMin;
+    protected int splatterRecursionsMax;
+
+    protected int seedPercent;
+    protected int growthPercent;
+    protected int splatterRecursions;
 
     public AbstractPerformerBrush() {
         this.performerProperties = PerformerRegistrar.DEFAULT_PERFORMER_PROPERTIES;
         PerformerCreator performerCreator = this.performerProperties.getCreator();
         this.performer = performerCreator.create();
+        this.performer.setProperties(this.performerProperties);
+        this.performer.loadProperties();
+    }
+
+    @Override
+    public void loadProperties() {
+        this.seedPercentMin = getIntegerProperty("seed-percent-min", SEED_PERCENT_MIN);
+        this.seedPercentMax = getIntegerProperty("seed-percent-max", SEED_PERCENT_MAX);
+        this.growthPercentMin = getIntegerProperty("growth-percent-min", GROWTH_PERCENT_MIN);
+        this.growthPercentMax = getIntegerProperty("growth-percent-max", GROWTH_PERCENT_MAX);
+        this.splatterRecursionsMin = getIntegerProperty("splatter-recursions-min", SPLATTER_RECURSIONS_MIN);
+        this.splatterRecursionsMax = getIntegerProperty("splatter-recursions-max", SPLATTER_RECURSIONS_MAX);
+
+        this.seedPercent = getIntegerProperty("default-seed-percent", DEFAULT_SEED_PERCENT);
+        this.growthPercent = getIntegerProperty("default-growth-percent", DEFAULT_GROWTH_PERCENT);
+        this.splatterRecursions = getIntegerProperty("default-splatter-recursions", DEFAULT_SPLATTER_RECURSIONS);
     }
 
     @Override
@@ -34,6 +75,8 @@ public abstract class AbstractPerformerBrush extends AbstractBrush implements Pe
         this.performerProperties = performerProperties;
         PerformerCreator performerCreator = this.performerProperties.getCreator();
         this.performer = performerCreator.create();
+        this.performer.setProperties(this.performerProperties);
+        this.performer.loadProperties();
         sendInfo(snipe);
         PerformerSnipe performerSnipe = new PerformerSnipe(snipe, this.performerProperties, this.performer);
         this.performer.sendInfo(performerSnipe);

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/BallBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/BallBrush.java
@@ -19,6 +19,10 @@ public class BallBrush extends AbstractPerformerBrush {
     private boolean trueCircle;
 
     @Override
+    public void loadProperties() {
+    }
+
+    @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
         String firstParameter = parameters[0];

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/BlobBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/BlobBrush.java
@@ -37,7 +37,8 @@ public class BlobBrush extends AbstractPerformerBrush {
                         this.growthPercent = growPercent;
                         messenger.sendMessage(ChatColor.AQUA + "Growth percent set to: " + this.growthPercent / 100 + "%");
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Growth percent must be an integer 1-9999!");
+                        messenger.sendMessage(ChatColor.RED + "Growth percent must be an integer " + this.growthPercentMin +
+                                "-" + this.growthPercentMax + ".");
                     }
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid brush parameters! Use the \"info\" parameter to display parameter info.");

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/BlobBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/BlobBrush.java
@@ -8,17 +8,17 @@ import com.thevoxelbox.voxelsniper.util.text.NumericParser;
 import org.bukkit.ChatColor;
 
 import java.util.List;
-import java.util.Random;
 import java.util.stream.Stream;
 
 public class BlobBrush extends AbstractPerformerBrush {
 
-    private static final int GROW_PERCENT_DEFAULT = 1000;
-    private static final int GROW_PERCENT_MIN = 1;
-    private static final int GROW_PERCENT_MAX = 9999;
+    @Override
+    public void loadProperties() {
+        this.growthPercentMin = getIntegerProperty("growth-percent-min", GROWTH_PERCENT_MIN);
+        this.growthPercentMax = getIntegerProperty("growth-percent-max", GROWTH_PERCENT_MAX);
 
-    private final Random randomGenerator = new Random();
-    private int growPercent = GROW_PERCENT_DEFAULT; // chance block on recursion pass is made active
+        this.growthPercent = getIntegerProperty("default-growth-percent", DEFAULT_GROWTH_PERCENT);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
@@ -27,15 +27,15 @@ public class BlobBrush extends AbstractPerformerBrush {
 
         if (firstParameter.equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.GOLD + "Blob Brush Brush Parameters:");
-            messenger.sendMessage(ChatColor.AQUA + "/b blob g [n] -- Sets the growth percentage to n (" + GROW_PERCENT_MIN +
-                    "-" + GROW_PERCENT_MAX + "). Default is " + GROW_PERCENT_DEFAULT + ".");
+            messenger.sendMessage(ChatColor.AQUA + "/b blob g [n] -- Sets the growth percentage to n (" + this.growthPercentMin +
+                    "-" + this.growthPercentMax + "). Default is " + DEFAULT_GROWTH_PERCENT + ".");
         } else {
             if (parameters.length == 2) {
                 if (firstParameter.equalsIgnoreCase("g")) {
                     Integer growPercent = NumericParser.parseInteger(parameters[1]);
-                    if (growPercent != null && growPercent >= GROW_PERCENT_MIN && growPercent <= GROW_PERCENT_MAX) {
-                        this.growPercent = growPercent;
-                        messenger.sendMessage(ChatColor.AQUA + "Growth percent set to: " + this.growPercent / 100 + "%");
+                    if (growPercent != null && growPercent >= super.growthPercentMin && growPercent <= super.growthPercentMax) {
+                        this.growthPercent = growPercent;
+                        messenger.sendMessage(ChatColor.AQUA + "Growth percent set to: " + this.growthPercent / 100 + "%");
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Growth percent must be an integer 1-9999!");
                     }
@@ -73,7 +73,7 @@ public class BlobBrush extends AbstractPerformerBrush {
         int brushSize = toolkitProperties.getBrushSize();
         if (checkValidGrowPercent()) {
             SnipeMessenger messenger = snipe.createMessenger();
-            messenger.sendMessage(ChatColor.BLUE + "Growth percent set to: 10%");
+            messenger.sendMessage(ChatColor.BLUE + "Growth percent set to: " + this.growthPercent / 100 + "%");
         }
         // Seed the array
         int brushSizeDoubled = 2 * brushSize;
@@ -81,8 +81,9 @@ public class BlobBrush extends AbstractPerformerBrush {
         for (int x = brushSizeDoubled; x >= 0; x--) {
             for (int y = brushSizeDoubled; y >= 0; y--) {
                 for (int z = brushSizeDoubled; z >= 0; z--) {
-                    splat[x][y][z] = (x == 0 || y == 0 | z == 0 || x == brushSizeDoubled || y == brushSizeDoubled || z == brushSizeDoubled) && this.randomGenerator
-                            .nextInt(GROW_PERCENT_MAX + 1) <= this.growPercent ? 0 : 1;
+                    splat[x][y][z] =
+                            (x == 0 || y == 0 | z == 0 || x == brushSizeDoubled || y == brushSizeDoubled || z == brushSizeDoubled) && super.generator
+                                    .nextInt(super.growthPercentMax + 1) <= this.growthPercent ? 0 : 1;
                 }
             }
         }
@@ -114,7 +115,7 @@ public class BlobBrush extends AbstractPerformerBrush {
                                 growCheck++;
                             }
                         }
-                        if (growCheck >= 1 && this.randomGenerator.nextInt(GROW_PERCENT_MAX + 1) <= this.growPercent) {
+                        if (growCheck >= 1 && super.generator.nextInt(super.growthPercentMax + 1) <= this.growthPercent) {
                             tempSplat[x][y][z] = 0; // prevent bleed into splat
                         }
                     }
@@ -159,7 +160,7 @@ public class BlobBrush extends AbstractPerformerBrush {
         int brushSize = toolkitProperties.getBrushSize();
         if (checkValidGrowPercent()) {
             SnipeMessenger messenger = snipe.createMessenger();
-            messenger.sendMessage(ChatColor.BLUE + "Growth percent set to: 10%");
+            messenger.sendMessage(ChatColor.BLUE + "Growth percent set to: " + this.growthPercent / 100 + "%");
         }
         // Seed the array
         int brushSizeDoubled = 2 * brushSize;
@@ -193,7 +194,7 @@ public class BlobBrush extends AbstractPerformerBrush {
                                 growCheck++;
                             }
                         }
-                        if (growCheck >= 1 && this.randomGenerator.nextInt(GROW_PERCENT_MAX + 1) <= this.growPercent) {
+                        if (growCheck >= 1 && super.generator.nextInt(super.growthPercentMax + 1) <= this.growthPercent) {
                             // prevent bleed into splat
                             tempSplat[x][y][z] = 1;
                         }
@@ -234,8 +235,8 @@ public class BlobBrush extends AbstractPerformerBrush {
     }
 
     private boolean checkValidGrowPercent() {
-        if (this.growPercent < GROW_PERCENT_MIN || this.growPercent > GROW_PERCENT_MAX) {
-            this.growPercent = GROW_PERCENT_DEFAULT;
+        if (this.growthPercent < super.growthPercentMin || this.growthPercent > super.growthPercentMax) {
+            this.growthPercent = getIntegerProperty("default-grow-percent", DEFAULT_GROWTH_PERCENT);
             return true;
         }
         return false;
@@ -247,7 +248,7 @@ public class BlobBrush extends AbstractPerformerBrush {
         snipe.createMessageSender()
                 .brushNameMessage()
                 .brushSizeMessage()
-                .message(ChatColor.BLUE + "Growth percent set to: " + this.growPercent / 100 + "%")
+                .message(ChatColor.BLUE + "Growth percent set to: " + this.growthPercent / 100 + "%")
                 .send();
     }
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/CheckerVoxelDiscBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/CheckerVoxelDiscBrush.java
@@ -14,6 +14,10 @@ public class CheckerVoxelDiscBrush extends AbstractPerformerBrush {
     private boolean useWorldCoordinates = true;
 
     @Override
+    public void loadProperties() {
+    }
+
+    @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
         String firstParameter = parameters[0];

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/CylinderBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/CylinderBrush.java
@@ -98,19 +98,26 @@ public class CylinderBrush extends AbstractPerformerBrush {
             yEndPoint = yStartingPoint;
         }
         EditSession editSession = getEditSession();
-        if (yStartingPoint < 0) {
-            yStartingPoint = 0;
+        int minHeight = editSession.getMinY();
+        if (yStartingPoint < minHeight) {
+            yStartingPoint = minHeight;
             messenger.sendMessage(ChatColor.DARK_PURPLE + "Warning: off-world start position.");
-        } else if (yStartingPoint > editSession.getMaxY()) {
-            yStartingPoint = editSession.getMaxY();
-            messenger.sendMessage(ChatColor.DARK_PURPLE + "Warning: off-world start position.");
+        } else {
+            int maxHeight = editSession.getMaxY();
+            if (yStartingPoint > maxHeight) {
+                yStartingPoint = maxHeight;
+                messenger.sendMessage(ChatColor.DARK_PURPLE + "Warning: off-world start position.");
+            }
         }
-        if (yEndPoint < 0) {
-            yEndPoint = 0;
+        if (yEndPoint < minHeight) {
+            yEndPoint = minHeight;
             messenger.sendMessage(ChatColor.DARK_PURPLE + "Warning: off-world end position.");
-        } else if (yEndPoint > editSession.getMaxY()) {
-            yEndPoint = editSession.getMaxY();
-            messenger.sendMessage(ChatColor.DARK_PURPLE + "Warning: off-world end position.");
+        } else {
+            int maxHeight = editSession.getMaxY();
+            if (yEndPoint > maxHeight) {
+                yEndPoint = maxHeight;
+                messenger.sendMessage(ChatColor.DARK_PURPLE + "Warning: off-world end position.");
+            }
         }
         int blockX = targetBlock.getX();
         int blockZ = targetBlock.getZ();

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/CylinderBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/CylinderBrush.java
@@ -16,6 +16,10 @@ public class CylinderBrush extends AbstractPerformerBrush {
     private double trueCircle;
 
     @Override
+    public void loadProperties() {
+    }
+
+    @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
         ToolkitProperties toolkitProperties = snipe.getToolkitProperties();

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/EllipseBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/EllipseBrush.java
@@ -15,18 +15,38 @@ import java.util.stream.Stream;
 public class EllipseBrush extends AbstractPerformerBrush {
 
     private static final double TWO_PI = (2 * Math.PI);
+
     private static final int SCL_MIN = 1;
     private static final int SCL_MAX = 9999;
-    private static final int SCL_DEFAULT = 10;
     private static final int STEPS_MIN = 1;
     private static final int STEPS_MAX = 2000;
-    private static final int STEPS_DEFAULT = 200;
+
+    private static final int DEFAULT_SCL = 10;
+    private static final int DEFAULT_STEPS = 200;
+
+    private boolean fill;
+    private double stepSize;
+
+    private int sclMin;
+    private int sclMax;
+    private int stepsMin;
+    private int stepsMax;
 
     private int xscl;
     private int yscl;
     private int steps;
-    private double stepSize;
-    private boolean fill;
+
+    @Override
+    public void loadProperties() {
+        this.sclMin = getIntegerProperty("scl-min", SCL_MIN);
+        this.sclMax = getIntegerProperty("scl-max", SCL_MAX);
+        this.stepsMin = getIntegerProperty("steps-min", STEPS_MIN);
+        this.stepsMax = getIntegerProperty("steps-max", STEPS_MAX);
+
+        this.xscl = getIntegerProperty("default-x-scl", DEFAULT_SCL);
+        this.yscl = getIntegerProperty("default-y-scl", DEFAULT_SCL);
+        this.steps = getIntegerProperty("default-steps", DEFAULT_STEPS);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
@@ -35,7 +55,7 @@ public class EllipseBrush extends AbstractPerformerBrush {
 
         if (firstParameter.equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.GOLD + "Ellipse Brush Parameters:");
-            messenger.sendMessage(ChatColor.AQUA + "/b el fill -- Toggles fill mode.");
+            messenger.sendMessage(ChatColor.AQUA + "/b el fill -- Toggles fill mode. Default is false.");
             messenger.sendMessage(ChatColor.AQUA + "/b el x [n] -- Sets X size modifier to n.");
             messenger.sendMessage(ChatColor.AQUA + "/b el y [n] -- Sets Y size modifier to n.");
             messenger.sendMessage(ChatColor.AQUA + "/b el t [n] -- Sets the amount of time steps.");
@@ -56,7 +76,7 @@ public class EllipseBrush extends AbstractPerformerBrush {
             } else if (parameters.length == 2) {
                 if (firstParameter.equalsIgnoreCase("x")) {
                     Integer xscl = NumericParser.parseInteger(parameters[1]);
-                    if (xscl != null && xscl >= SCL_MIN && xscl <= SCL_MAX) {
+                    if (xscl != null && xscl >= this.sclMin && xscl <= this.sclMax) {
                         this.xscl = xscl;
                         messenger.sendMessage(ChatColor.AQUA + "X-scale modifier set to: " + this.xscl);
                     } else {
@@ -64,7 +84,7 @@ public class EllipseBrush extends AbstractPerformerBrush {
                     }
                 } else if (firstParameter.equalsIgnoreCase("y")) {
                     Integer yscl = NumericParser.parseInteger(parameters[1]);
-                    if (yscl != null && yscl >= SCL_MIN && yscl <= SCL_MAX) {
+                    if (yscl != null && yscl >= this.sclMin && yscl <= this.sclMax) {
                         this.yscl = yscl;
                         messenger.sendMessage(ChatColor.AQUA + "Y-scale modifier set to: " + this.yscl);
                     } else {
@@ -72,7 +92,7 @@ public class EllipseBrush extends AbstractPerformerBrush {
                     }
                 } else if (firstParameter.equalsIgnoreCase("t")) {
                     Integer steps = NumericParser.parseInteger(parameters[1]);
-                    if (steps != null && steps >= STEPS_MIN && steps <= STEPS_MAX) {
+                    if (steps != null && steps >= this.stepsMin && steps <= this.stepsMax) {
                         this.steps = steps;
                         messenger.sendMessage(ChatColor.AQUA + "Render step number set to: " + this.steps);
                     } else {
@@ -291,14 +311,14 @@ public class EllipseBrush extends AbstractPerformerBrush {
 
     @Override
     public void sendInfo(Snipe snipe) {
-        if (this.xscl < SCL_MIN || this.xscl > SCL_MAX) {
-            this.xscl = SCL_DEFAULT;
+        if (this.xscl < this.sclMin || this.xscl > this.sclMax) {
+            this.xscl = getIntegerProperty("scl-default", DEFAULT_SCL);
         }
-        if (this.yscl < SCL_MIN || this.yscl > SCL_MAX) {
-            this.yscl = SCL_DEFAULT;
+        if (this.yscl < this.sclMin || this.yscl > this.sclMax) {
+            this.yscl = getIntegerProperty("scl-default", DEFAULT_SCL);
         }
-        if (this.steps < STEPS_MIN || this.steps > STEPS_MAX) {
-            this.steps = STEPS_DEFAULT;
+        if (this.steps < this.stepsMin || this.steps > this.stepsMax) {
+            this.steps = getIntegerProperty("default-steps", DEFAULT_STEPS);
         }
         SnipeMessageSender messageSender = snipe.createMessageSender();
         messageSender.brushNameMessage()

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/EllipseBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/EllipseBrush.java
@@ -1,5 +1,6 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
+import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Direction;
 import com.thevoxelbox.voxelsniper.sniper.snipe.Snipe;
@@ -175,15 +176,16 @@ public class EllipseBrush extends AbstractPerformerBrush {
     }
 
     private void ellipseFill(Snipe snipe, BlockVector3 targetBlock) {
+        EditSession editSession = getEditSession();
         int ix = this.xscl;
         int iy = this.yscl;
         int blockX = targetBlock.getX();
         int blockY = targetBlock.getY();
         int blockZ = targetBlock.getZ();
-        this.performer.perform(getEditSession(), blockX, blockY, blockZ, getBlock(blockX, blockY, blockZ));
+        this.performer.perform(editSession, blockX, blockY, blockZ, getBlock(blockX, blockY, blockZ));
         try {
             if (ix >= iy) { // Need this unless you want weird holes
-                for (iy = this.yscl; iy > 0; iy--) {
+                for (iy = this.yscl; iy >= editSession.getMinY(); iy--) {
                     for (double steps = 0; (steps <= TWO_PI); steps += this.stepSize) {
                         int x = (int) Math.round(ix * Math.cos(steps));
                         int y = (int) Math.round(iy * Math.sin(steps));
@@ -232,7 +234,7 @@ public class EllipseBrush extends AbstractPerformerBrush {
                     ix--;
                 }
             } else {
-                for (ix = this.xscl; ix > 0; ix--) {
+                for (ix = this.xscl; ix >= editSession.getMinY(); ix--) {
                     for (double steps = 0; (steps <= TWO_PI); steps += this.stepSize) {
                         int x = (int) Math.round(ix * Math.cos(steps));
                         int y = (int) Math.round(iy * Math.sin(steps));

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/EllipsoidBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/EllipsoidBrush.java
@@ -11,10 +11,15 @@ import java.util.stream.Stream;
 
 public class EllipsoidBrush extends AbstractPerformerBrush {
 
-    private double xRad;
-    private double yRad;
-    private double zRad;
+    private static final int DEFAULT_X_RAD = 0;
+    private static final int DEFAULT_Y_RAD = 0;
+    private static final int DEFAULT_Z_RAD = 0;
+
     private boolean offset;
+
+    private double xRad = DEFAULT_X_RAD;
+    private double yRad = DEFAULT_Y_RAD;
+    private double zRad = DEFAULT_Z_RAD;
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/EllipsoidBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/EllipsoidBrush.java
@@ -28,7 +28,7 @@ public class EllipsoidBrush extends AbstractPerformerBrush {
 
         if (firstParameter.equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.GOLD + "Ellipse Brush Parameters:");
-            messenger.sendMessage(ChatColor.AQUA + "/b elo [true|false] -- Toggles offset.");
+            messenger.sendMessage(ChatColor.AQUA + "/b elo [true|false] -- Toggles offset. Default is false.");
             messenger.sendMessage(ChatColor.AQUA + "/b elo x [n] -- Sets X radius to n.");
             messenger.sendMessage(ChatColor.AQUA + "/b elo y [n] -- Sets Y radius to n.");
             messenger.sendMessage(ChatColor.AQUA + "/b elo z [n] -- Sets Z radius to n.");

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/FillDownBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/FillDownBrush.java
@@ -18,6 +18,10 @@ public class FillDownBrush extends AbstractPerformerBrush {
     private boolean fromExisting;
 
     @Override
+    public void loadProperties() {
+    }
+
+    @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
         String firstParameter = parameters[0];

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/JaggedLineBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/JaggedLineBrush.java
@@ -34,7 +34,7 @@ public class JaggedLineBrush extends AbstractPerformerBrush {
     private int recursionMin;
     private int recursionMax;
 
-    private int recursion;
+    private int recursions;
     private int spread;
 
     @Override
@@ -42,7 +42,7 @@ public class JaggedLineBrush extends AbstractPerformerBrush {
         this.recursionMin = getIntegerProperty("recursion-min", RECURSION_MIN);
         this.recursionMax = getIntegerProperty("recursion-max", RECURSION_MAX);
 
-        this.recursion = getIntegerProperty("defaut-recursion", DEFAULT_RECURSION);
+        this.recursions = getIntegerProperty("defaut-recursion", DEFAULT_RECURSION);
         this.spread = getIntegerProperty("defaut-spread", DEFAULT_SPREAD);
     }
 
@@ -55,17 +55,21 @@ public class JaggedLineBrush extends AbstractPerformerBrush {
             messenger.sendMessage(ChatColor.DARK_AQUA + "Right click first point with the arrow. Right click with gunpowder to " +
                     "draw a jagged line to set the second point.");
             messenger.sendMessage(ChatColor.GOLD + "Jagged Line Brush Parameters:");
-            messenger.sendMessage(ChatColor.AQUA + "/b j r [n] - Sets the number of recursions to n. (default 3, must be 1-10)");
-            messenger.sendMessage(ChatColor.AQUA + "/b j s [n] - Sets the spread to n. (default 3, must be 1-10)");
+            messenger.sendMessage(ChatColor.AQUA + "/b j r [n] - Sets the number of recursions to n. Default is " +
+                    getIntegerProperty("defaut-recursion", DEFAULT_RECURSION) + ", must be an integer " + this.recursionMin +
+                    "-" + this.recursionMax + ".");
+            messenger.sendMessage(ChatColor.AQUA + "/b j s [n] - Sets the spread to n. Default is " +
+                    getIntegerProperty("defaut-spread", DEFAULT_SPREAD) + ".");
         } else {
             if (parameters.length == 2) {
                 if (firstParameter.equalsIgnoreCase("r")) {
-                    Integer recursion = NumericParser.parseInteger(parameters[1]);
-                    if (recursion != null && recursion >= this.recursionMin && recursion <= this.recursionMax) {
-                        this.recursion = recursion;
-                        messenger.sendMessage(ChatColor.GREEN + "Recursion set to: " + this.recursion);
+                    Integer recursions = NumericParser.parseInteger(parameters[1]);
+                    if (recursions != null && recursions >= this.recursionMin && recursions <= this.recursionMax) {
+                        this.recursions = recursions;
+                        messenger.sendMessage(ChatColor.GREEN + "Recursions set to: " + this.recursions);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Recusions must be an integer " + this.recursionMin +
+                                "-" + this.recursionMax + ".");
                     }
                 } else if (firstParameter.equalsIgnoreCase("s")) {
                     Integer spread = NumericParser.parseInteger(parameters[1]);
@@ -141,7 +145,7 @@ public class JaggedLineBrush extends AbstractPerformerBrush {
             BlockIterator iterator = new BlockIterator(world, originClone, direction, 0, NumberConversions.round(length));
             while (iterator.hasNext()) {
                 Block block = iterator.next();
-                for (int i = 0; i < this.recursion; i++) {
+                for (int i = 0; i < this.recursions; i++) {
                     int x = Math.round(block.getX() + this.random.nextInt(this.spread * 2) - this.spread);
                     int y = Math.round(block.getY() + this.random.nextInt(this.spread * 2) - this.spread);
                     int z = Math.round(block.getZ() + this.random.nextInt(this.spread * 2) - this.spread);
@@ -155,7 +159,7 @@ public class JaggedLineBrush extends AbstractPerformerBrush {
     public void sendInfo(Snipe snipe) {
         snipe.createMessageSender()
                 .brushNameMessage()
-                .message(ChatColor.GRAY + "Recursion set to: " + this.recursion)
+                .message(ChatColor.GRAY + "Recursion set to: " + this.recursions)
                 .message(ChatColor.GRAY + "Spread set to: " + this.spread)
                 .send();
     }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/JaggedLineBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/JaggedLineBrush.java
@@ -20,16 +20,31 @@ import java.util.stream.Stream;
 public class JaggedLineBrush extends AbstractPerformerBrush {
 
     private static final Vector HALF_BLOCK_OFFSET = new Vector(0.5, 0.5, 0.5);
+
     private static final int RECURSION_MIN = 1;
-    private static final int RECURSION_DEFAULT = 3;
     private static final int RECURSION_MAX = 10;
-    private static final int SPREAD_DEFAULT = 3;
+
+    private static final int DEFAULT_RECURSION = 3;
+    private static final int DEFAULT_SPREAD = 3;
 
     private final Random random = new Random();
     private Vector originCoordinates;
     private Vector targetCoordinates = new Vector();
-    private int recursion = RECURSION_DEFAULT;
-    private int spread = SPREAD_DEFAULT;
+
+    private int recursionMin;
+    private int recursionMax;
+
+    private int recursion;
+    private int spread;
+
+    @Override
+    public void loadProperties() {
+        this.recursionMin = getIntegerProperty("recursion-min", RECURSION_MIN);
+        this.recursionMax = getIntegerProperty("recursion-max", RECURSION_MAX);
+
+        this.recursion = getIntegerProperty("defaut-recursion", DEFAULT_RECURSION);
+        this.spread = getIntegerProperty("defaut-spread", DEFAULT_SPREAD);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
@@ -46,7 +61,7 @@ public class JaggedLineBrush extends AbstractPerformerBrush {
             if (parameters.length == 2) {
                 if (firstParameter.equalsIgnoreCase("r")) {
                     Integer recursion = NumericParser.parseInteger(parameters[1]);
-                    if (recursion != null && recursion >= RECURSION_MIN && recursion <= RECURSION_MAX) {
+                    if (recursion != null && recursion >= this.recursionMin && recursion <= this.recursionMax) {
                         this.recursion = recursion;
                         messenger.sendMessage(ChatColor.GREEN + "Recursion set to: " + this.recursion);
                     } else {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/LineBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/LineBrush.java
@@ -16,9 +16,14 @@ import org.bukkit.util.Vector;
 public class LineBrush extends AbstractPerformerBrush {
 
     private static final Vector HALF_BLOCK_OFFSET = new Vector(0.5, 0.5, 0.5);
+
     private Vector originCoordinates;
     private Vector targetCoordinates = new Vector();
     private World targetWorld;
+
+    @Override
+    public void loadProperties() {
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/OverlayBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/OverlayBrush.java
@@ -19,8 +19,14 @@ public class OverlayBrush extends AbstractPerformerBrush {
 
     private static final int DEFAULT_DEPTH = 3;
 
-    private int depth = DEFAULT_DEPTH;
     private boolean allBlocks;
+
+    private int depth;
+
+    @Override
+    public void loadProperties() {
+        this.depth = getIntegerProperty("default-depth", DEFAULT_DEPTH);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/OverlayBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/OverlayBrush.java
@@ -1,5 +1,6 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
+import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
@@ -85,6 +86,7 @@ public class OverlayBrush extends AbstractPerformerBrush {
 
     private void overlay(Snipe snipe) {
         ToolkitProperties toolkitProperties = snipe.getToolkitProperties();
+        EditSession editSession = getEditSession();
         int brushSize = toolkitProperties.getBrushSize();
         double brushSizeSquared = Math.pow(brushSize + 0.5, 2);
         for (int z = brushSize; z >= -brushSize; z--) {
@@ -98,7 +100,7 @@ public class OverlayBrush extends AbstractPerformerBrush {
                 BlockType type = getBlockType(blockX + x, blockY + 1, blockZ + z);
                 if (isIgnoredBlock(type)) {
                     if (Math.pow(x, 2) + Math.pow(z, 2) <= brushSizeSquared) {
-                        for (int y = blockY; y > 0; y--) {
+                        for (int y = blockY; y >= editSession.getMinY(); y--) {
                             // check for surface
                             BlockType layerBlockType = getBlockType(blockX + x, y, blockZ + z);
                             if (!isIgnoredBlock(layerBlockType)) {
@@ -136,6 +138,7 @@ public class OverlayBrush extends AbstractPerformerBrush {
 
     private void overlayTwo(Snipe snipe) {
         ToolkitProperties toolkitProperties = snipe.getToolkitProperties();
+        EditSession editSession = getEditSession();
         int brushSize = toolkitProperties.getBrushSize();
         double brushSizeSquared = Math.pow(brushSize + 0.5, 2);
         int[][] memory = new int[brushSize * 2 + 1][brushSize * 2 + 1];
@@ -146,7 +149,7 @@ public class OverlayBrush extends AbstractPerformerBrush {
                 int blockX = targetBlock.getX();
                 int blockY = targetBlock.getY();
                 int blockZ = targetBlock.getZ();
-                for (int y = blockY; y > 0 && !surfaceFound; y--) { // start scanning from the height you clicked at
+                for (int y = blockY; y >= editSession.getMinY() && !surfaceFound; y--) { // start scanning from the height you clicked at
                     if (memory[x + brushSize][z + brushSize] != 1) { // if haven't already found the surface in this column
                         if ((Math.pow(x, 2) + Math.pow(z, 2)) <= brushSizeSquared) { // if inside of the column...
                             if (!Materials.isEmpty(getBlockType(

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/PunishBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/PunishBrush.java
@@ -29,23 +29,41 @@ import java.util.stream.Stream;
 
 public class PunishBrush extends AbstractPerformerBrush {
 
+    private static final int TICKS_PER_SECOND = 20;
+
+    private static final int MAX_RANDOM_TELEPORTATION_RANGE = 400;
+    private static final int INFINI_PUNISH_SIZE = -3;
+
+    private static final Punishment DEFAULT_PUNISHMENT = Punishment.FIRE;
+    private static final int DEFAULT_PUNISH_LEVEL = 10;
+    private static final int DEFAULT_PUNISH_DURATION = 60;
+
     private static final List<String> PUNISHMENTS = Arrays.stream(Punishment.values())
             .map(punishment -> punishment.name().toLowerCase(Locale.ROOT))
             .collect(Collectors.toList());
 
-    private static final int MAX_RANDOM_TELEPORTATION_RANGE = 400;
-    private static final int TICKS_PER_SECOND = 20;
-    private static final int INFINIPUNISH_SIZE = -3;
-    private static final int DEFAULT_PUNISH_LEVEL = 10;
-    private static final int DEFAULT_PUNISH_DURATION = 60;
 
-    private Punishment punishment = Punishment.FIRE;
-    private int punishLevel = DEFAULT_PUNISH_LEVEL;
-    private int punishDuration = DEFAULT_PUNISH_DURATION;
     private boolean specificPlayer;
     private String punishPlayerName = "";
     private boolean hypnoAffectLandscape;
     private boolean hitsSelf;
+
+    private int maxRandomTeleportationRange;
+    private int infiniPunishSize;
+
+    private Punishment punishment;
+    private int punishLevel;
+    private int punishDuration;
+
+    @Override
+    public void loadProperties() {
+        this.maxRandomTeleportationRange = getIntegerProperty("max-random-teleportation-range", MAX_RANDOM_TELEPORTATION_RANGE);
+        this.infiniPunishSize = getIntegerProperty("infini-punish-size", INFINI_PUNISH_SIZE);
+
+        this.punishment = (Punishment) getEnumProperty("default-punishment", Punishment.class, DEFAULT_PUNISHMENT);
+        this.punishLevel = getIntegerProperty("default-punish-level", DEFAULT_PUNISH_LEVEL);
+        this.punishDuration = getIntegerProperty("default-punish-duration", DEFAULT_PUNISH_DURATION);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
@@ -182,7 +200,7 @@ public class PunishBrush extends AbstractPerformerBrush {
                             messenger.sendMessage("An error occured.");
                             return null;
                         }
-                    } else if (brushSize == INFINIPUNISH_SIZE) {
+                    } else if (brushSize == this.infiniPunishSize) {
                         numPunishApps++;
                         applyPunishment(entity, snipe);
                     }
@@ -303,8 +321,8 @@ public class PunishBrush extends AbstractPerformerBrush {
             case RANDOMTP:
                 Random random = new Random();
                 Location targetLocation = entity.getLocation();
-                targetLocation.setX(targetLocation.getX() + (random.nextInt(MAX_RANDOM_TELEPORTATION_RANGE) - MAX_RANDOM_TELEPORTATION_RANGE / 2.0));
-                targetLocation.setZ(targetLocation.getZ() + (random.nextInt(MAX_RANDOM_TELEPORTATION_RANGE) - MAX_RANDOM_TELEPORTATION_RANGE / 2.0));
+                targetLocation.setX(targetLocation.getX() + (random.nextInt(this.maxRandomTeleportationRange) - this.maxRandomTeleportationRange / 2.0));
+                targetLocation.setZ(targetLocation.getZ() + (random.nextInt(this.maxRandomTeleportationRange) - this.maxRandomTeleportationRange / 2.0));
                 entity.teleport(targetLocation);
                 break;
             case ALL_POTION:

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/PunishBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/PunishBrush.java
@@ -69,7 +69,9 @@ public class PunishBrush extends AbstractPerformerBrush {
                             Arrays.stream(Punishment.values())
                                     .map(punishment -> ((punishment == this.punishment) ? ChatColor.GOLD : ChatColor.GRAY) +
                                             punishment.name())
-                                    .collect(Collectors.joining(ChatColor.WHITE + ", "))
+                                    .collect(Collectors.joining(ChatColor.WHITE + ", ",
+                                            ChatColor.AQUA + "Available punishments: ", ""
+                                    ))
                     );
                 } else if (firstParameter.equalsIgnoreCase("toggleSelf")) {
                     this.hitsSelf = !this.hitsSelf;

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/PunishBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/PunishBrush.java
@@ -351,7 +351,7 @@ public class PunishBrush extends AbstractPerformerBrush {
 
     private void addEffect(LivingEntity entity, PotionEffectType type) {
         PotionEffect effect = new PotionEffect(type, TICKS_PER_SECOND * this.punishDuration, this.punishLevel);
-        entity.addPotionEffect(effect, true);
+        entity.addPotionEffect(effect);
     }
 
     @Override

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/PunishBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/PunishBrush.java
@@ -102,7 +102,7 @@ public class PunishBrush extends AbstractPerformerBrush {
                     this.hypnoAffectLandscape = !this.hypnoAffectLandscape;
                 } else {
                     try {
-                        this.punishment = Punishment.valueOf(firstParameter);
+                        this.punishment = Punishment.valueOf(firstParameter.toUpperCase(Locale.ROOT));
                         messenger.sendMessage(ChatColor.AQUA + this.punishment.name()
                                 .toLowerCase(Locale.ROOT) + " punishment selected.");
                     } catch (IllegalArgumentException exception) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/RingBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/RingBrush.java
@@ -45,7 +45,7 @@ public class RingBrush extends AbstractPerformerBrush {
                     Double innerSize = NumericParser.parseDouble(parameters[1]);
                     if (innerSize != null) {
                         this.innerSize = innerSize;
-                        messenger.sendMessage(ChatColor.AQUA + "The inner radius has been set to " + ChatColor.RED + this.innerSize);
+                        messenger.sendMessage(ChatColor.AQUA + "The inner radius has been set to: " + ChatColor.RED + this.innerSize);
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");
                     }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/RingBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/RingBrush.java
@@ -12,8 +12,11 @@ import java.util.stream.Stream;
 
 public class RingBrush extends AbstractPerformerBrush {
 
+    private static final double DEFAULT_INNER_SIZE = 0.0;
+
     private double trueCircle;
-    private double innerSize;
+
+    private double innerSize = DEFAULT_INNER_SIZE;
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/SetBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/SetBrush.java
@@ -66,8 +66,8 @@ public class SetBrush extends AbstractPerformerBrush {
         int highX = Math.max(x1, x2);
         int highY = Math.max(y1, y2);
         int highZ = Math.max(z1, z2);
-        if (Math.abs(highX - lowX) * Math.abs(highZ - lowZ) * Math.abs(highY - lowY) > selectionSizeMax) {
-            messenger.sendMessage(ChatColor.RED + "Selection size above hardcoded limit, please use a smaller selection.");
+        if (Math.abs(highX - lowX) * Math.abs(highZ - lowZ) * Math.abs(highY - lowY) > this.selectionSizeMax) {
+            messenger.sendMessage(ChatColor.RED + "Selection size above " + this.selectionSizeMax + " limit, please use a smaller selection.");
         } else {
             for (int y = lowY; y <= highY; y++) {
                 for (int x = lowX; x <= highX; x++) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/SetBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/SetBrush.java
@@ -15,6 +15,13 @@ public class SetBrush extends AbstractPerformerBrush {
     private BlockVector3 block;
     private World world;
 
+    private int selectionSizeMax;
+
+    @Override
+    public void loadProperties() {
+        this.selectionSizeMax = getIntegerProperty("selection-size-max", SELECTION_SIZE_MAX);
+    }
+
     @Override
     public void handleArrowAction(Snipe snipe) {
         BlockVector3 targetBlock = getTargetBlock();
@@ -59,7 +66,7 @@ public class SetBrush extends AbstractPerformerBrush {
         int highX = Math.max(x1, x2);
         int highY = Math.max(y1, y2);
         int highZ = Math.max(z1, z2);
-        if (Math.abs(highX - lowX) * Math.abs(highZ - lowZ) * Math.abs(highY - lowY) > SELECTION_SIZE_MAX) {
+        if (Math.abs(highX - lowX) * Math.abs(highZ - lowZ) * Math.abs(highY - lowY) > selectionSizeMax) {
             messenger.sendMessage(ChatColor.RED + "Selection size above hardcoded limit, please use a smaller selection.");
         } else {
             for (int y = lowY; y <= highY; y++) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/SnipeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/SnipeBrush.java
@@ -7,6 +7,10 @@ import com.thevoxelbox.voxelsniper.sniper.snipe.message.SnipeMessenger;
 public class SnipeBrush extends AbstractPerformerBrush {
 
     @Override
+    public void loadProperties() {
+    }
+
+    @Override
     public void handleArrowAction(Snipe snipe) {
         BlockVector3 targetBlock = getTargetBlock();
         this.performer.perform(

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/SplineBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/SplineBrush.java
@@ -23,6 +23,10 @@ public class SplineBrush extends AbstractPerformerBrush {
     private boolean ctrl;
 
     @Override
+    public void loadProperties() {
+    }
+
+    @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
         String firstParameter = parameters[0];

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/ThreePointCircleBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/ThreePointCircleBrush.java
@@ -62,8 +62,8 @@ public class ThreePointCircleBrush extends AbstractPerformerBrush {
                     );
                 } else {
                     try {
-                        this.tolerance = Tolerance.valueOf(firstParameter);
-                        messenger.sendMessage(ChatColor.AQUA + "Brush set to " + this.tolerance.name()
+                        this.tolerance = Tolerance.valueOf(firstParameter.toUpperCase(Locale.ROOT));
+                        messenger.sendMessage(ChatColor.AQUA + "Brush set to: " + this.tolerance.name()
                                 .toLowerCase(Locale.ROOT) + " tolerance.");
                     } catch (IllegalArgumentException exception) {
                         messenger.sendMessage(ChatColor.RED + "Invalid tolerance.");

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/ThreePointCircleBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/ThreePointCircleBrush.java
@@ -48,7 +48,9 @@ public class ThreePointCircleBrush extends AbstractPerformerBrush {
                             Arrays.stream(Tolerance.values())
                                     .map(tolerance -> ((tolerance == this.tolerance) ? ChatColor.GOLD : ChatColor.GRAY) +
                                             tolerance.name().toLowerCase(Locale.ROOT))
-                                    .collect(Collectors.joining(ChatColor.WHITE + ", "))
+                                    .collect(Collectors.joining(ChatColor.WHITE + ", ",
+                                            ChatColor.AQUA + "Available tolerances: ", ""
+                                    ))
                     );
                 } else {
                     try {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/ThreePointCircleBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/ThreePointCircleBrush.java
@@ -18,6 +18,8 @@ import java.util.stream.Stream;
 
 public class ThreePointCircleBrush extends AbstractPerformerBrush {
 
+    private static final Tolerance DEFAULT_TOLERANCE = Tolerance.DEFAULT;
+
     private static final List<String> TOLERANCES = Arrays.stream(Tolerance.values())
             .map(tolerance -> tolerance.name().toLowerCase(Locale.ROOT))
             .collect(Collectors.toList());
@@ -28,7 +30,13 @@ public class ThreePointCircleBrush extends AbstractPerformerBrush {
     private Vector coordinatesTwo;
     @Nullable
     private Vector coordinatesThree;
-    private Tolerance tolerance = Tolerance.DEFAULT;
+
+    private Tolerance tolerance;
+
+    @Override
+    public void loadProperties() {
+        this.tolerance = (Tolerance) getEnumProperty("default-tolerance", Tolerance.class, DEFAULT_TOLERANCE);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/TriangleBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/TriangleBrush.java
@@ -22,6 +22,10 @@ public class TriangleBrush extends AbstractPerformerBrush {
     private int cornerNumber = 1;
 
     @Override
+    public void loadProperties() {
+    }
+
+    @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
         String firstParameter = parameters[0];

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/UnderlayBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/UnderlayBrush.java
@@ -15,8 +15,14 @@ public class UnderlayBrush extends AbstractPerformerBrush {
 
     private static final int DEFAULT_DEPTH = 3;
 
-    private int depth = DEFAULT_DEPTH;
     private boolean allBlocks;
+
+    private int depth;
+
+    @Override
+    public void loadProperties() {
+        this.depth = getIntegerProperty("default-depth", DEFAULT_DEPTH);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/UnderlayBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/UnderlayBrush.java
@@ -31,11 +31,11 @@ public class UnderlayBrush extends AbstractPerformerBrush {
 
         if (firstParameter.equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.GOLD + "Underlay Brush Parameters:");
-            messenger.sendMessage(ChatColor.BLUE + "/b over all -- Sets the brush to overlay over ALL materials, not just " +
+            messenger.sendMessage(ChatColor.BLUE + "/b under all -- Sets the brush to overlay over ALL materials, not just " +
                     "natural surface ones (will no longer ignore trees and buildings).");
-            messenger.sendMessage(ChatColor.BLUE + "/b over some -- Sets the brush to overlay over natural surface " +
+            messenger.sendMessage(ChatColor.BLUE + "/b under some -- Sets the brush to overlay over natural surface " +
                     "materials.");
-            messenger.sendMessage(ChatColor.AQUA + "/b over d [n] -- Sets the number of blocks thick to change to n.");
+            messenger.sendMessage(ChatColor.AQUA + "/b under d [n] -- Sets the number of blocks thick to change to n.");
         } else {
             if (parameters.length == 1) {
                 if (firstParameter.equalsIgnoreCase("all")) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/UnderlayBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/UnderlayBrush.java
@@ -31,9 +31,9 @@ public class UnderlayBrush extends AbstractPerformerBrush {
 
         if (firstParameter.equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.GOLD + "Underlay Brush Parameters:");
-            messenger.sendMessage(ChatColor.BLUE + "/b under all -- Sets the brush to overlay over ALL materials, not just " +
+            messenger.sendMessage(ChatColor.AQUA + "/b under all -- Sets the brush to overlay over ALL materials, not just " +
                     "natural surface ones (will no longer ignore trees and buildings).");
-            messenger.sendMessage(ChatColor.BLUE + "/b under some -- Sets the brush to overlay over natural surface " +
+            messenger.sendMessage(ChatColor.AQUA + "/b under some -- Sets the brush to overlay over natural surface " +
                     "materials.");
             messenger.sendMessage(ChatColor.AQUA + "/b under d [n] -- Sets the number of blocks thick to change to n.");
         } else {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/VoxelBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/VoxelBrush.java
@@ -7,6 +7,10 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 public class VoxelBrush extends AbstractPerformerBrush {
 
     @Override
+    public void loadProperties() {
+    }
+
+    @Override
     public void handleArrowAction(Snipe snipe) {
         voxel(snipe);
     }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/disc/DiscBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/disc/DiscBrush.java
@@ -16,6 +16,10 @@ public class DiscBrush extends AbstractPerformerBrush {
     private double trueCircle;
 
     @Override
+    public void loadProperties() {
+    }
+
+    @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
         String firstParameter = parameters[0];

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/disc/DiscBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/disc/DiscBrush.java
@@ -1,13 +1,12 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer.disc;
 
+import com.fastasyncworldedit.core.math.MutableBlockVector3;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.thevoxelbox.voxelsniper.brush.type.performer.AbstractPerformerBrush;
 import com.thevoxelbox.voxelsniper.sniper.snipe.Snipe;
 import com.thevoxelbox.voxelsniper.sniper.snipe.message.SnipeMessenger;
 import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
-import com.thevoxelbox.voxelsniper.util.Vectors;
 import org.bukkit.ChatColor;
-import org.bukkit.util.Vector;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -68,13 +67,12 @@ public class DiscBrush extends AbstractPerformerBrush {
         ToolkitProperties toolkitProperties = snipe.getToolkitProperties();
         int brushSize = toolkitProperties.getBrushSize();
         double radiusSquared = (brushSize + this.trueCircle) * (brushSize + this.trueCircle);
-        Vector centerPoint = Vectors.toBukkit(targetBlock);
-        Vector currentPoint = new Vector().copy(centerPoint);
+        MutableBlockVector3 currentPoint = new MutableBlockVector3(targetBlock);
         for (int x = -brushSize; x <= brushSize; x++) {
-            currentPoint.setX(centerPoint.getX() + x);
+            currentPoint.mutX(targetBlock.getX() + x);
             for (int z = -brushSize; z <= brushSize; z++) {
-                currentPoint.setZ(centerPoint.getZ() + z);
-                if (centerPoint.distanceSquared(currentPoint) <= radiusSquared) {
+                currentPoint.mutZ(targetBlock.getZ() + z);
+                if (targetBlock.distanceSq(currentPoint) <= radiusSquared) {
                     this.performer.perform(
                             getEditSession(),
                             currentPoint.getBlockX(),

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/disc/DiscFaceBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/disc/DiscFaceBrush.java
@@ -16,6 +16,10 @@ public class DiscFaceBrush extends AbstractPerformerBrush {
     private double trueCircle;
 
     @Override
+    public void loadProperties() {
+    }
+
+    @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
         String firstParameter = parameters[0];

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/disc/VoxelDiscBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/disc/VoxelDiscBrush.java
@@ -8,6 +8,10 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 public class VoxelDiscBrush extends AbstractPerformerBrush {
 
     @Override
+    public void loadProperties() {
+    }
+
+    @Override
     public void handleArrowAction(Snipe snipe) {
         BlockVector3 targetBlock = getTargetBlock();
         disc(snipe, targetBlock);

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/disc/VoxelDiscFaceBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/disc/VoxelDiscFaceBrush.java
@@ -9,6 +9,10 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 public class VoxelDiscFaceBrush extends AbstractPerformerBrush {
 
     @Override
+    public void loadProperties() {
+    }
+
+    @Override
     public void handleArrowAction(Snipe snipe) {
         BlockVector3 lastBlock = getLastBlock();
         BlockVector3 targetBlock = getTargetBlock();

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterBallBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterBallBrush.java
@@ -32,7 +32,8 @@ public class SplatterBallBrush extends AbstractPerformerBrush {
                         this.seedPercent = seedPercent;
                         messenger.sendMessage(ChatColor.AQUA + "Seed percent set to: " + this.seedPercent / 100 + "%");
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Seed percent must be an integer 1-9999!");
+                        messenger.sendMessage(ChatColor.RED + "Seed percent must be an integer " + this.seedPercentMin +
+                                "-" + this.seedPercentMax + ".");
                     }
                 } else if (firstParameter.equalsIgnoreCase("g")) {
                     Integer growPercent = NumericParser.parseInteger(parameters[1]);
@@ -40,7 +41,8 @@ public class SplatterBallBrush extends AbstractPerformerBrush {
                         this.growthPercent = growPercent;
                         messenger.sendMessage(ChatColor.AQUA + "Growth percent set to: " + this.growthPercent / 100 + "%");
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Growth percent must be an integer 1-9999!");
+                        messenger.sendMessage(ChatColor.RED + "Growth percent must be an integer " + this.growthPercentMin +
+                                "-" + this.growthPercentMax + ".");
                     }
                 } else if (firstParameter.equalsIgnoreCase("r")) {
                     Integer splatterRecursions = NumericParser.parseInteger(parameters[1]);
@@ -49,7 +51,8 @@ public class SplatterBallBrush extends AbstractPerformerBrush {
                         this.splatterRecursions = splatterRecursions;
                         messenger.sendMessage(ChatColor.AQUA + "Recursions set to: " + this.splatterRecursions);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Recursions must be an integer 1-10!");
+                        messenger.sendMessage(ChatColor.RED + "Recursions must be an integer " + this.splatterRecursionsMin +
+                                "-" + this.splatterRecursionsMax + ".");
                     }
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid brush parameters! Use the \"info\" parameter to display parameter info.");

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterDiscBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterDiscBrush.java
@@ -9,24 +9,9 @@ import com.thevoxelbox.voxelsniper.util.text.NumericParser;
 import org.bukkit.ChatColor;
 
 import java.util.List;
-import java.util.Random;
 import java.util.stream.Stream;
 
 public class SplatterDiscBrush extends AbstractPerformerBrush {
-
-    private static final int GROW_PERCENT_MIN = 1;
-    private static final int GROW_PERCENT_DEFAULT = 1000;
-    private static final int GROW_PERCENT_MAX = 9999;
-    private static final int SEED_PERCENT_MIN = 1;
-    private static final int SEED_PERCENT_DEFAULT = 1000;
-    private static final int SEED_PERCENT_MAX = 9999;
-    private static final int SPLATTER_RECURSIONS_PERCENT_MIN = 1;
-    private static final int SPLATTER_RECURSIONS_PERCENT_DEFAULT = 3;
-    private static final int SPLATTER_RECURSIONS_PERCENT_MAX = 10;
-    private final Random generator = new Random();
-    private int seedPercent; // Chance block on first pass is made active
-    private int growPercent; // chance block on recursion pass is made active
-    private int splatterRecursions; // How many times you grow the seeds
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
@@ -43,7 +28,7 @@ public class SplatterDiscBrush extends AbstractPerformerBrush {
             if (parameters.length == 2) {
                 if (firstParameter.equalsIgnoreCase("s")) {
                     Integer seedPercent = NumericParser.parseInteger(parameters[1]);
-                    if (seedPercent != null && seedPercent >= SEED_PERCENT_MIN && seedPercent <= SEED_PERCENT_MAX) {
+                    if (seedPercent != null && seedPercent >= super.seedPercentMin && seedPercent <= super.seedPercentMax) {
                         this.seedPercent = seedPercent;
                         messenger.sendMessage(ChatColor.AQUA + "Seed percent set to: " + this.seedPercent / 100 + "%");
                     } else {
@@ -51,16 +36,16 @@ public class SplatterDiscBrush extends AbstractPerformerBrush {
                     }
                 } else if (firstParameter.equalsIgnoreCase("g")) {
                     Integer growPercent = NumericParser.parseInteger(parameters[1]);
-                    if (growPercent != null && growPercent >= GROW_PERCENT_MIN && growPercent <= GROW_PERCENT_MAX) {
-                        this.growPercent = growPercent;
+                    if (growPercent != null && growPercent >= super.growthPercentMin && growPercent <= super.growthPercentMax) {
+                        this.growthPercent = growPercent;
                         messenger.sendMessage(ChatColor.AQUA + "Growth percent set to: " + growPercent / 100 + "%");
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Growth percent must be an integer 1-9999!");
                     }
                 } else if (firstParameter.equalsIgnoreCase("r")) {
                     Integer splatterRecursions = NumericParser.parseInteger(parameters[1]);
-                    if (splatterRecursions != null && splatterRecursions >= SPLATTER_RECURSIONS_PERCENT_MIN
-                            && splatterRecursions <= SPLATTER_RECURSIONS_PERCENT_MAX) {
+                    if (splatterRecursions != null && splatterRecursions >= super.splatterRecursionsMin
+                            && splatterRecursions <= super.splatterRecursionsMax) {
                         this.splatterRecursions = splatterRecursions;
                         messenger.sendMessage(ChatColor.AQUA + "Recursions set to: " + this.splatterRecursions);
                     } else {
@@ -100,33 +85,33 @@ public class SplatterDiscBrush extends AbstractPerformerBrush {
     private void splatterDisc(Snipe snipe, BlockVector3 targetBlock) {
         ToolkitProperties toolkitProperties = snipe.getToolkitProperties();
         SnipeMessenger messenger = snipe.createMessenger();
-        if (this.seedPercent < SEED_PERCENT_MIN || this.seedPercent > SEED_PERCENT_MAX) {
-            messenger.sendMessage(ChatColor.BLUE + "Seed percent set to: 10%");
-            this.seedPercent = SEED_PERCENT_DEFAULT;
+        if (this.seedPercent < super.seedPercentMin || this.seedPercent > super.seedPercentMax) {
+            this.seedPercent = getIntegerProperty("default-seed-percent", DEFAULT_SEED_PERCENT);
+            messenger.sendMessage(ChatColor.BLUE + "Seed percent set to: " + this.seedPercent / 100 + "%");
         }
-        if (this.growPercent < GROW_PERCENT_MIN || this.growPercent > GROW_PERCENT_MAX) {
-            messenger.sendMessage(ChatColor.BLUE + "Growth percent set to: 10%");
-            this.growPercent = GROW_PERCENT_DEFAULT;
+        if (this.growthPercent < super.growthPercentMin || this.growthPercent > super.growthPercentMax) {
+            this.growthPercent = getIntegerProperty("default-grow-percent", DEFAULT_GROWTH_PERCENT);
+            messenger.sendMessage(ChatColor.BLUE + "Growth percent set to: " + this.growthPercent / 100 + "%");
         }
-        if (this.splatterRecursions < SPLATTER_RECURSIONS_PERCENT_MIN || this.splatterRecursions > SPLATTER_RECURSIONS_PERCENT_MAX) {
-            messenger.sendMessage(ChatColor.BLUE + "Recursions set to: 3");
-            this.splatterRecursions = SPLATTER_RECURSIONS_PERCENT_DEFAULT;
+        if (this.splatterRecursions < super.splatterRecursionsMin || this.splatterRecursions > super.splatterRecursionsMax) {
+            this.splatterRecursions = getIntegerProperty("default-splatter-recursions", DEFAULT_SPLATTER_RECURSIONS);
+            messenger.sendMessage(ChatColor.BLUE + "Recursions set to: " + this.splatterRecursions);
         }
         int brushSize = toolkitProperties.getBrushSize();
         int[][] splat = new int[2 * brushSize + 1][2 * brushSize + 1];
         // Seed the array
         for (int x = 2 * brushSize; x >= 0; x--) {
             for (int y = 2 * brushSize; y >= 0; y--) {
-                if (this.generator.nextInt(SEED_PERCENT_MAX + 1) <= this.seedPercent) {
+                if (super.generator.nextInt(super.seedPercentMax + 1) <= this.seedPercent) {
                     splat[x][y] = 1;
                 }
             }
         }
         // Grow the seeds
-        int gref = this.growPercent;
+        int gref = this.growthPercent;
         int[][] tempSplat = new int[2 * brushSize + 1][2 * brushSize + 1];
         for (int r = 0; r < this.splatterRecursions; r++) {
-            this.growPercent = gref - ((gref / this.splatterRecursions) * (r));
+            this.growthPercent = gref - ((gref / this.splatterRecursions) * (r));
             for (int x = 2 * brushSize; x >= 0; x--) {
                 for (int y = 2 * brushSize; y >= 0; y--) {
                     tempSplat[x][y] = splat[x][y]; // prime tempsplat
@@ -145,7 +130,7 @@ public class SplatterDiscBrush extends AbstractPerformerBrush {
                             growcheck++;
                         }
                     }
-                    if (growcheck >= 1 && this.generator.nextInt(GROW_PERCENT_MAX + 1) <= this.growPercent) {
+                    if (growcheck >= 1 && super.generator.nextInt(super.growthPercentMax + 1) <= this.growthPercent) {
                         tempSplat[x][y] = 1; // prevent bleed into splat
                     }
                 }
@@ -157,7 +142,7 @@ public class SplatterDiscBrush extends AbstractPerformerBrush {
                 }
             }
         }
-        this.growPercent = gref;
+        this.growthPercent = gref;
         // Fill 1x1 holes
         for (int x = 2 * brushSize; x >= 0; x--) {
             for (int y = 2 * brushSize; y >= 0; y--) {
@@ -191,20 +176,20 @@ public class SplatterDiscBrush extends AbstractPerformerBrush {
 
     @Override
     public void sendInfo(Snipe snipe) {
-        if (this.seedPercent < SEED_PERCENT_MIN || this.seedPercent > SEED_PERCENT_MAX) {
-            this.seedPercent = SEED_PERCENT_DEFAULT;
+        if (this.seedPercent < super.seedPercentMin || this.seedPercent > super.seedPercentMax) {
+            this.seedPercent = getIntegerProperty("default-seed-percent", DEFAULT_SEED_PERCENT);
         }
-        if (this.growPercent < GROW_PERCENT_MIN || this.growPercent > GROW_PERCENT_MAX) {
-            this.growPercent = GROW_PERCENT_DEFAULT;
+        if (this.growthPercent < super.growthPercentMin || this.growthPercent > super.growthPercentMax) {
+            this.growthPercent = getIntegerProperty("default-grow-percent", DEFAULT_GROWTH_PERCENT);
         }
-        if (this.splatterRecursions < SPLATTER_RECURSIONS_PERCENT_MIN || this.splatterRecursions > SPLATTER_RECURSIONS_PERCENT_MAX) {
-            this.splatterRecursions = SPLATTER_RECURSIONS_PERCENT_DEFAULT;
+        if (this.splatterRecursions < super.splatterRecursionsMin || this.splatterRecursions > super.splatterRecursionsMax) {
+            this.splatterRecursions = getIntegerProperty("default-splatter-recursions", DEFAULT_SPLATTER_RECURSIONS);
         }
         snipe.createMessageSender()
                 .brushNameMessage()
                 .brushSizeMessage()
                 .message(ChatColor.BLUE + "Seed percent set to: " + this.seedPercent / 100 + "%")
-                .message(ChatColor.BLUE + "Growth percent set to: " + this.growPercent / 100 + "%")
+                .message(ChatColor.BLUE + "Growth percent set to: " + this.growthPercent / 100 + "%")
                 .message(ChatColor.BLUE + "Recursions set to: " + this.splatterRecursions)
                 .send();
     }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterDiscBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterDiscBrush.java
@@ -32,7 +32,8 @@ public class SplatterDiscBrush extends AbstractPerformerBrush {
                         this.seedPercent = seedPercent;
                         messenger.sendMessage(ChatColor.AQUA + "Seed percent set to: " + this.seedPercent / 100 + "%");
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Seed percent must be an integer 1-9999!");
+                        messenger.sendMessage(ChatColor.RED + "Seed percent must be an integer " + this.seedPercentMin +
+                                "-" + this.seedPercentMax + ".");
                     }
                 } else if (firstParameter.equalsIgnoreCase("g")) {
                     Integer growPercent = NumericParser.parseInteger(parameters[1]);
@@ -40,7 +41,8 @@ public class SplatterDiscBrush extends AbstractPerformerBrush {
                         this.growthPercent = growPercent;
                         messenger.sendMessage(ChatColor.AQUA + "Growth percent set to: " + growPercent / 100 + "%");
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Growth percent must be an integer 1-9999!");
+                        messenger.sendMessage(ChatColor.RED + "Growth percent must be an integer " + this.growthPercentMin +
+                                "-" + this.growthPercentMax + ".");
                     }
                 } else if (firstParameter.equalsIgnoreCase("r")) {
                     Integer splatterRecursions = NumericParser.parseInteger(parameters[1]);
@@ -49,7 +51,8 @@ public class SplatterDiscBrush extends AbstractPerformerBrush {
                         this.splatterRecursions = splatterRecursions;
                         messenger.sendMessage(ChatColor.AQUA + "Recursions set to: " + this.splatterRecursions);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Recursions must be an integer 1-10!");
+                        messenger.sendMessage(ChatColor.RED + "Recursions must be an integer " + this.splatterRecursionsMin +
+                                "-" + this.splatterRecursionsMax + ".");
                     }
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid brush parameters! Use the \"info\" parameter to display parameter info.");

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterOverlayBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterOverlayBrush.java
@@ -1,5 +1,6 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer.splatter;
 
+import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
@@ -144,6 +145,7 @@ public class SplatterOverlayBrush extends AbstractPerformerBrush {
 
     private void splatterOverlay(Snipe snipe) {
         ToolkitProperties toolkitProperties = snipe.getToolkitProperties();
+        EditSession editSession = getEditSession();
         // Splatter Time
         int brushSize = toolkitProperties.getBrushSize();
         int[][] splat = new int[2 * brushSize + 1][2 * brushSize + 1];
@@ -198,7 +200,7 @@ public class SplatterOverlayBrush extends AbstractPerformerBrush {
                 BlockVector3 targetBlock = this.getTargetBlock();
                 int blockX = targetBlock.getX();
                 int blockZ = targetBlock.getZ();
-                for (int y = targetBlock.getY(); y > 0; y--) {
+                for (int y = targetBlock.getY(); y >= editSession.getMinY(); y--) {
                     // start scanning from the height you clicked at
                     if (memory[x + brushSize][z + brushSize] != 1) {
                         // if haven't already found the surface in this column
@@ -254,6 +256,7 @@ public class SplatterOverlayBrush extends AbstractPerformerBrush {
 
     private void splatterOverlayTwo(Snipe snipe) {
         ToolkitProperties toolkitProperties = snipe.getToolkitProperties();
+        EditSession editSession = getEditSession();
         // Splatter Time
         int brushSize = toolkitProperties.getBrushSize();
         int[][] splat = new int[2 * brushSize + 1][2 * brushSize + 1];
@@ -308,7 +311,7 @@ public class SplatterOverlayBrush extends AbstractPerformerBrush {
                 BlockVector3 targetBlock = this.getTargetBlock();
                 int blockX = targetBlock.getX();
                 int blockZ = targetBlock.getZ();
-                for (int y = targetBlock.getY(); y > 0; y--) { // start scanning from the height you clicked at
+                for (int y = targetBlock.getY(); y >= editSession.getMinY(); y--) { // start scanning from the height you clicked at
                     if (memory[x + brushSize][z + brushSize] != 1) { // if haven't already found the surface in this column
                         if ((Math.pow(x, 2) + Math.pow(
                                 z,

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterOverlayBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterOverlayBrush.java
@@ -84,7 +84,8 @@ public class SplatterOverlayBrush extends AbstractPerformerBrush {
                         this.seedPercent = seedPercent;
                         messenger.sendMessage(ChatColor.AQUA + "Seed percent set to: " + this.seedPercent / 100 + "%");
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Seed percent must be an integer 1-9999!");
+                        messenger.sendMessage(ChatColor.RED + "Seed percent must be an integer " + this.seedPercentMin +
+                                "-" + this.seedPercentMax + ".");
                     }
                 } else if (firstParameter.equalsIgnoreCase("g")) {
                     Integer growPercent = NumericParser.parseInteger(parameters[1]);
@@ -92,7 +93,8 @@ public class SplatterOverlayBrush extends AbstractPerformerBrush {
                         this.growthPercent = growPercent;
                         messenger.sendMessage(ChatColor.AQUA + "Growth percent set to: " + this.growthPercent / 100 + "%");
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Growth percent must be an integer 1-9999!");
+                        messenger.sendMessage(ChatColor.RED + "Growth percent must be an integer " + this.growthPercentMin +
+                                "-" + this.growthPercentMax + ".");
                     }
                 } else if (firstParameter.equalsIgnoreCase("r")) {
                     Integer splatterRecursions = NumericParser.parseInteger(parameters[1]);
@@ -101,7 +103,8 @@ public class SplatterOverlayBrush extends AbstractPerformerBrush {
                         this.splatterRecursions = splatterRecursions;
                         messenger.sendMessage(ChatColor.AQUA + "Recursions set to: " + this.splatterRecursions);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Recursions must be an integer 1-10!");
+                        messenger.sendMessage(ChatColor.RED + "Recursions must be an integer " + this.splatterRecursionsMin +
+                                "-" + this.splatterRecursionsMax + ".");
                     }
                 } else if (firstParameter.equalsIgnoreCase("yoff")) {
                     Integer yOffset = NumericParser.parseInteger(parameters[1]);

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterVoxelBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterVoxelBrush.java
@@ -32,7 +32,8 @@ public class SplatterVoxelBrush extends AbstractPerformerBrush {
                         this.seedPercent = seedPercent;
                         messenger.sendMessage(ChatColor.AQUA + "Seed percent set to: " + this.seedPercent / 100 + "%");
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Seed percent must be an integer 1-9999!");
+                        messenger.sendMessage(ChatColor.RED + "Seed percent must be an integer " + this.seedPercentMin +
+                                "-" + this.seedPercentMax + ".");
                     }
                 } else if (firstParameter.equalsIgnoreCase("g")) {
                     Integer growPercent = NumericParser.parseInteger(parameters[1]);
@@ -40,7 +41,8 @@ public class SplatterVoxelBrush extends AbstractPerformerBrush {
                         this.growthPercent = growPercent;
                         messenger.sendMessage(ChatColor.AQUA + "Growth percent set to: " + this.growthPercent / 100 + "%");
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Growth percent must be an integer 1-9999!");
+                        messenger.sendMessage(ChatColor.RED + "Growth percent must be an integer " + this.growthPercentMin +
+                                "-" + this.growthPercentMax + ".");
                     }
                 } else if (firstParameter.equalsIgnoreCase("r")) {
                     Integer splatterRecursions = NumericParser.parseInteger(parameters[1]);
@@ -49,7 +51,8 @@ public class SplatterVoxelBrush extends AbstractPerformerBrush {
                         this.splatterRecursions = splatterRecursions;
                         messenger.sendMessage(ChatColor.AQUA + "Recursions set to: " + this.splatterRecursions);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Recursions must be an integer 1-10!");
+                        messenger.sendMessage(ChatColor.RED + "Recursions must be an integer " + this.splatterRecursionsMin +
+                                "-" + this.splatterRecursionsMax + ".");
                     }
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid brush parameters! Use the \"info\" parameter to display parameter info.");

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterVoxelBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterVoxelBrush.java
@@ -9,24 +9,9 @@ import com.thevoxelbox.voxelsniper.util.text.NumericParser;
 import org.bukkit.ChatColor;
 
 import java.util.List;
-import java.util.Random;
 import java.util.stream.Stream;
 
 public class SplatterVoxelBrush extends AbstractPerformerBrush {
-
-    private static final int GROW_PERCENT_MIN = 1;
-    private static final int GROW_PERCENT_DEFAULT = 1000;
-    private static final int GROW_PERCENT_MAX = 9999;
-    private static final int SEED_PERCENT_MIN = 1;
-    private static final int SEED_PERCENT_DEFAULT = 1000;
-    private static final int SEED_PERCENT_MAX = 9999;
-    private static final int SPLATTER_RECURSIONS_PERCENT_MIN = 1;
-    private static final int SPLATTER_RECURSIONS_PERCENT_DEFAULT = 3;
-    private static final int SPLATTER_RECURSIONS_PERCENT_MAX = 10;
-    private final Random generator = new Random();
-    private int seedPercent; // Chance block on first pass is made active
-    private int growPercent; // chance block on recursion pass is made active
-    private int splatterRecursions; // How many times you grow the seeds
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
@@ -43,7 +28,7 @@ public class SplatterVoxelBrush extends AbstractPerformerBrush {
             if (parameters.length == 2) {
                 if (firstParameter.equalsIgnoreCase("s")) {
                     Integer seedPercent = NumericParser.parseInteger(parameters[1]);
-                    if (seedPercent != null && seedPercent >= SEED_PERCENT_MIN && seedPercent <= SEED_PERCENT_MAX) {
+                    if (seedPercent != null && seedPercent >= super.seedPercentMin && seedPercent <= super.seedPercentMax) {
                         this.seedPercent = seedPercent;
                         messenger.sendMessage(ChatColor.AQUA + "Seed percent set to: " + this.seedPercent / 100 + "%");
                     } else {
@@ -51,16 +36,16 @@ public class SplatterVoxelBrush extends AbstractPerformerBrush {
                     }
                 } else if (firstParameter.equalsIgnoreCase("g")) {
                     Integer growPercent = NumericParser.parseInteger(parameters[1]);
-                    if (growPercent != null && growPercent >= GROW_PERCENT_MIN && growPercent <= GROW_PERCENT_MAX) {
-                        this.growPercent = growPercent;
-                        messenger.sendMessage(ChatColor.AQUA + "Growth percent set to: " + this.growPercent / 100 + "%");
+                    if (growPercent != null && growPercent >= super.growthPercentMin && growPercent <= super.growthPercentMax) {
+                        this.growthPercent = growPercent;
+                        messenger.sendMessage(ChatColor.AQUA + "Growth percent set to: " + this.growthPercent / 100 + "%");
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Growth percent must be an integer 1-9999!");
                     }
                 } else if (firstParameter.equalsIgnoreCase("r")) {
                     Integer splatterRecursions = NumericParser.parseInteger(parameters[1]);
-                    if (splatterRecursions != null && splatterRecursions >= SPLATTER_RECURSIONS_PERCENT_MIN
-                            && splatterRecursions <= SPLATTER_RECURSIONS_PERCENT_MAX) {
+                    if (splatterRecursions != null && splatterRecursions >= super.splatterRecursionsMin
+                            && splatterRecursions <= super.splatterRecursionsMax) {
                         this.splatterRecursions = splatterRecursions;
                         messenger.sendMessage(ChatColor.AQUA + "Recursions set to: " + this.splatterRecursions);
                     } else {
@@ -100,17 +85,17 @@ public class SplatterVoxelBrush extends AbstractPerformerBrush {
     private void voxelSplatterBall(Snipe snipe, BlockVector3 targetBlock) {
         ToolkitProperties toolkitProperties = snipe.getToolkitProperties();
         SnipeMessenger messenger = snipe.createMessenger();
-        if (this.seedPercent < SEED_PERCENT_MIN || this.seedPercent > SEED_PERCENT_MAX) {
-            messenger.sendMessage(ChatColor.BLUE + "Seed percent set to: 10%");
-            this.seedPercent = SEED_PERCENT_DEFAULT;
+        if (this.seedPercent < super.seedPercentMin || this.seedPercent > super.seedPercentMax) {
+            this.seedPercent = getIntegerProperty("default-seed-percent", DEFAULT_SEED_PERCENT);
+            messenger.sendMessage(ChatColor.BLUE + "Seed percent set to: " + this.seedPercent / 100 + "%");
         }
-        if (this.growPercent < GROW_PERCENT_MIN || this.growPercent > GROW_PERCENT_MAX) {
-            messenger.sendMessage(ChatColor.BLUE + "Growth percent set to: 10%");
-            this.growPercent = GROW_PERCENT_DEFAULT;
+        if (this.growthPercent < super.growthPercentMin || this.growthPercent > super.growthPercentMax) {
+            this.growthPercent = getIntegerProperty("default-grow-percent", DEFAULT_GROWTH_PERCENT);
+            messenger.sendMessage(ChatColor.BLUE + "Growth percent set to: " + this.growthPercent / 100 + "%");
         }
-        if (this.splatterRecursions < SPLATTER_RECURSIONS_PERCENT_MIN || this.splatterRecursions > SPLATTER_RECURSIONS_PERCENT_MAX) {
-            messenger.sendMessage(ChatColor.BLUE + "Recursions set to: 3");
-            this.splatterRecursions = SPLATTER_RECURSIONS_PERCENT_DEFAULT;
+        if (this.splatterRecursions < super.splatterRecursionsMin || this.splatterRecursions > super.splatterRecursionsMax) {
+            this.splatterRecursions = getIntegerProperty("default-splatter-recursions", DEFAULT_SPLATTER_RECURSIONS);
+            messenger.sendMessage(ChatColor.BLUE + "Recursions set to: " + this.splatterRecursions);
         }
         int brushSize = toolkitProperties.getBrushSize();
         int[][][] splat = new int[2 * brushSize + 1][2 * brushSize + 1][2 * brushSize + 1];
@@ -118,17 +103,17 @@ public class SplatterVoxelBrush extends AbstractPerformerBrush {
         for (int x = 2 * brushSize; x >= 0; x--) {
             for (int y = 2 * brushSize; y >= 0; y--) {
                 for (int z = 2 * brushSize; z >= 0; z--) {
-                    if (this.generator.nextInt(SEED_PERCENT_MAX + 1) <= this.seedPercent) {
+                    if (super.generator.nextInt(super.seedPercentMax + 1) <= this.seedPercent) {
                         splat[x][y][z] = 1;
                     }
                 }
             }
         }
         // Grow the seeds
-        int gref = this.growPercent;
+        int gref = this.growthPercent;
         int[][][] tempSplat = new int[2 * brushSize + 1][2 * brushSize + 1][2 * brushSize + 1];
         for (int r = 0; r < this.splatterRecursions; r++) {
-            this.growPercent = gref - ((gref / this.splatterRecursions) * (r));
+            this.growthPercent = gref - ((gref / this.splatterRecursions) * (r));
             for (int x = 2 * brushSize; x >= 0; x--) {
                 for (int y = 2 * brushSize; y >= 0; y--) {
                     for (int z = 2 * brushSize; z >= 0; z--) {
@@ -154,7 +139,7 @@ public class SplatterVoxelBrush extends AbstractPerformerBrush {
                                 growcheck++;
                             }
                         }
-                        if (growcheck >= 1 && this.generator.nextInt(GROW_PERCENT_MAX + 1) <= this.growPercent) {
+                        if (growcheck >= 1 && super.generator.nextInt(super.growthPercentMax + 1) <= this.growthPercent) {
                             tempSplat[x][y][z] = 1; // prevent bleed into splat
                         }
                     }
@@ -169,7 +154,7 @@ public class SplatterVoxelBrush extends AbstractPerformerBrush {
                 }
             }
         }
-        this.growPercent = gref;
+        this.growthPercent = gref;
         // Fill 1x1x1 holes
         for (int x = 2 * brushSize; x >= 0; x--) {
             for (int y = 2 * brushSize; y >= 0; y--) {
@@ -206,20 +191,20 @@ public class SplatterVoxelBrush extends AbstractPerformerBrush {
 
     @Override
     public void sendInfo(Snipe snipe) {
-        if (this.seedPercent < SEED_PERCENT_MIN || this.seedPercent > SEED_PERCENT_MAX) {
-            this.seedPercent = SEED_PERCENT_DEFAULT;
+        if (this.seedPercent < super.seedPercentMin || this.seedPercent > super.seedPercentMax) {
+            this.seedPercent = getIntegerProperty("default-seed-percent", DEFAULT_SEED_PERCENT);
         }
-        if (this.growPercent < GROW_PERCENT_MIN || this.growPercent > GROW_PERCENT_MAX) {
-            this.growPercent = GROW_PERCENT_DEFAULT;
+        if (this.growthPercent < super.growthPercentMin || this.growthPercent > super.growthPercentMax) {
+            this.growthPercent = getIntegerProperty("default-grow-percent", DEFAULT_GROWTH_PERCENT);
         }
-        if (this.splatterRecursions < SPLATTER_RECURSIONS_PERCENT_MIN || this.splatterRecursions > SPLATTER_RECURSIONS_PERCENT_MAX) {
-            this.splatterRecursions = SPLATTER_RECURSIONS_PERCENT_DEFAULT;
+        if (this.splatterRecursions < super.splatterRecursionsMin || this.splatterRecursions > super.splatterRecursionsMax) {
+            this.splatterRecursions = getIntegerProperty("default-splatter-recursions", DEFAULT_SPLATTER_RECURSIONS);
         }
         snipe.createMessageSender()
                 .brushNameMessage()
                 .brushSizeMessage()
                 .message(ChatColor.BLUE + "Seed percent set to: " + this.seedPercent / 100 + "%")
-                .message(ChatColor.BLUE + "Growth percent set to: " + this.growPercent / 100 + "%")
+                .message(ChatColor.BLUE + "Growth percent set to: " + this.growthPercent / 100 + "%")
                 .message(ChatColor.BLUE + "Recursions set to: " + this.splatterRecursions)
                 .send();
     }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterVoxelDiscBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterVoxelDiscBrush.java
@@ -32,7 +32,8 @@ public class SplatterVoxelDiscBrush extends AbstractPerformerBrush {
                         this.seedPercent = seedPercent;
                         messenger.sendMessage(ChatColor.AQUA + "Seed percent set to: " + this.seedPercent / 100 + "%");
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Seed percent must be an integer 1-9999!");
+                        messenger.sendMessage(ChatColor.RED + "Seed percent must be an integer " + this.seedPercentMin +
+                                "-" + this.seedPercentMax + ".");
                     }
                 } else if (firstParameter.equalsIgnoreCase("g")) {
                     Integer growPercent = NumericParser.parseInteger(parameters[1]);
@@ -40,7 +41,8 @@ public class SplatterVoxelDiscBrush extends AbstractPerformerBrush {
                         this.growthPercent = growPercent;
                         messenger.sendMessage(ChatColor.AQUA + "Growth percent set to: " + this.growthPercent / 100 + "%");
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Growth percent must be an integer 1-9999!");
+                        messenger.sendMessage(ChatColor.RED + "Growth percent must be an integer " + this.growthPercentMin +
+                                "-" + this.growthPercentMax + ".");
                     }
                 } else if (firstParameter.equalsIgnoreCase("r")) {
                     Integer splatterRecursions = NumericParser.parseInteger(parameters[1]);
@@ -49,7 +51,8 @@ public class SplatterVoxelDiscBrush extends AbstractPerformerBrush {
                         this.splatterRecursions = splatterRecursions;
                         messenger.sendMessage(ChatColor.AQUA + "Recursions set to: " + this.splatterRecursions);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Recursions must be an integer 1-10!");
+                        messenger.sendMessage(ChatColor.RED + "Recursions must be an integer " + this.splatterRecursionsMin +
+                                "-" + this.splatterRecursionsMax + ".");
                     }
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid brush parameters! Use the \"info\" parameter to display parameter info.");

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterVoxelDiscBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterVoxelDiscBrush.java
@@ -9,24 +9,9 @@ import com.thevoxelbox.voxelsniper.util.text.NumericParser;
 import org.bukkit.ChatColor;
 
 import java.util.List;
-import java.util.Random;
 import java.util.stream.Stream;
 
 public class SplatterVoxelDiscBrush extends AbstractPerformerBrush {
-
-    private static final int GROW_PERCENT_MIN = 1;
-    private static final int GROW_PERCENT_DEFAULT = 1000;
-    private static final int GROW_PERCENT_MAX = 9999;
-    private static final int SEED_PERCENT_MIN = 1;
-    private static final int SEED_PERCENT_DEFAULT = 1000;
-    private static final int SEED_PERCENT_MAX = 9999;
-    private static final int SPLATTER_RECURSIONS_PERCENT_MIN = 1;
-    private static final int SPLATTER_RECURSIONS_PERCENT_DEFAULT = 3;
-    private static final int SPLATTER_RECURSIONS_PERCENT_MAX = 10;
-    private final Random generator = new Random();
-    private int seedPercent; // Chance block on first pass is made active
-    private int growPercent; // chance block on recursion pass is made active
-    private int splatterRecursions; // How many times you grow the seeds
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
@@ -43,7 +28,7 @@ public class SplatterVoxelDiscBrush extends AbstractPerformerBrush {
             if (parameters.length == 2) {
                 if (firstParameter.equalsIgnoreCase("s")) {
                     Integer seedPercent = NumericParser.parseInteger(parameters[1]);
-                    if (seedPercent != null && seedPercent >= SEED_PERCENT_MIN && seedPercent <= SEED_PERCENT_MAX) {
+                    if (seedPercent != null && seedPercent >= super.seedPercentMin && seedPercent <= super.seedPercentMax) {
                         this.seedPercent = seedPercent;
                         messenger.sendMessage(ChatColor.AQUA + "Seed percent set to: " + this.seedPercent / 100 + "%");
                     } else {
@@ -51,16 +36,16 @@ public class SplatterVoxelDiscBrush extends AbstractPerformerBrush {
                     }
                 } else if (firstParameter.equalsIgnoreCase("g")) {
                     Integer growPercent = NumericParser.parseInteger(parameters[1]);
-                    if (growPercent != null && growPercent >= GROW_PERCENT_MIN && growPercent <= GROW_PERCENT_MAX) {
-                        this.growPercent = growPercent;
-                        messenger.sendMessage(ChatColor.AQUA + "Growth percent set to: " + this.growPercent / 100 + "%");
+                    if (growPercent != null && growPercent >= super.growthPercentMin && growPercent <= super.growthPercentMax) {
+                        this.growthPercent = growPercent;
+                        messenger.sendMessage(ChatColor.AQUA + "Growth percent set to: " + this.growthPercent / 100 + "%");
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Growth percent must be an integer 1-9999!");
                     }
                 } else if (firstParameter.equalsIgnoreCase("r")) {
                     Integer splatterRecursions = NumericParser.parseInteger(parameters[1]);
-                    if (splatterRecursions != null && splatterRecursions >= SPLATTER_RECURSIONS_PERCENT_MIN
-                            && splatterRecursions <= SPLATTER_RECURSIONS_PERCENT_MAX) {
+                    if (splatterRecursions != null && splatterRecursions >= super.splatterRecursionsMin
+                            && splatterRecursions <= super.splatterRecursionsMax) {
                         this.splatterRecursions = splatterRecursions;
                         messenger.sendMessage(ChatColor.AQUA + "Recursions set to: " + this.splatterRecursions);
                     } else {
@@ -100,33 +85,33 @@ public class SplatterVoxelDiscBrush extends AbstractPerformerBrush {
     private void vSplatterDisc(Snipe snipe, BlockVector3 targetBlock) {
         ToolkitProperties toolkitProperties = snipe.getToolkitProperties();
         SnipeMessenger messenger = snipe.createMessenger();
-        if (this.seedPercent < SEED_PERCENT_MIN || this.seedPercent > SEED_PERCENT_MAX) {
-            messenger.sendMessage(ChatColor.BLUE + "Seed percent set to: 10%");
-            this.seedPercent = SEED_PERCENT_DEFAULT;
+        if (this.seedPercent < super.seedPercentMin || this.seedPercent > super.seedPercentMax) {
+            this.seedPercent = getIntegerProperty("default-seed-percent", DEFAULT_SEED_PERCENT);
+            messenger.sendMessage(ChatColor.BLUE + "Seed percent set to: " + this.seedPercent / 100 + "%");
         }
-        if (this.growPercent < GROW_PERCENT_MIN || this.growPercent > GROW_PERCENT_MAX) {
-            messenger.sendMessage(ChatColor.BLUE + "Growth percent set to: 10%");
-            this.growPercent = GROW_PERCENT_DEFAULT;
+        if (this.growthPercent < super.growthPercentMin || this.growthPercent > super.growthPercentMax) {
+            this.growthPercent = getIntegerProperty("default-grow-percent", DEFAULT_GROWTH_PERCENT);
+            messenger.sendMessage(ChatColor.BLUE + "Growth percent set to: " + this.growthPercent / 100 + "%");
         }
-        if (this.splatterRecursions < SPLATTER_RECURSIONS_PERCENT_MIN || this.splatterRecursions > SPLATTER_RECURSIONS_PERCENT_MAX) {
-            messenger.sendMessage(ChatColor.BLUE + "Recursions set to: 3");
-            this.splatterRecursions = SPLATTER_RECURSIONS_PERCENT_DEFAULT;
+        if (this.splatterRecursions < super.splatterRecursionsMin || this.splatterRecursions > super.splatterRecursionsMax) {
+            this.splatterRecursions = getIntegerProperty("default-splatter-recursions", DEFAULT_SPLATTER_RECURSIONS);
+            messenger.sendMessage(ChatColor.BLUE + "Recursions set to: " + this.splatterRecursions);
         }
         int brushSize = toolkitProperties.getBrushSize();
         int[][] splat = new int[2 * brushSize + 1][2 * brushSize + 1];
         // Seed the array
         for (int x = 2 * brushSize; x >= 0; x--) {
             for (int y = 2 * brushSize; y >= 0; y--) {
-                if (this.generator.nextInt(SEED_PERCENT_MAX + 1) <= this.seedPercent) {
+                if (super.generator.nextInt(super.seedPercentMax + 1) <= this.seedPercent) {
                     splat[x][y] = 1;
                 }
             }
         }
         // Grow the seeds
-        int gref = this.growPercent;
+        int gref = this.growthPercent;
         int[][] tempSplat = new int[2 * brushSize + 1][2 * brushSize + 1];
         for (int r = 0; r < this.splatterRecursions; r++) {
-            this.growPercent = gref - ((gref / this.splatterRecursions) * (r));
+            this.growthPercent = gref - ((gref / this.splatterRecursions) * (r));
             for (int x = 2 * brushSize; x >= 0; x--) {
                 for (int y = 2 * brushSize; y >= 0; y--) {
                     tempSplat[x][y] = splat[x][y]; // prime tempsplat
@@ -145,7 +130,7 @@ public class SplatterVoxelDiscBrush extends AbstractPerformerBrush {
                             growcheck++;
                         }
                     }
-                    if (growcheck >= 1 && this.generator.nextInt(GROW_PERCENT_MAX + 1) <= this.growPercent) {
+                    if (growcheck >= 1 && super.generator.nextInt(super.growthPercentMax + 1) <= this.growthPercent) {
                         tempSplat[x][y] = 1; // prevent bleed into splat
                     }
                 }
@@ -157,7 +142,7 @@ public class SplatterVoxelDiscBrush extends AbstractPerformerBrush {
                 }
             }
         }
-        this.growPercent = gref;
+        this.growthPercent = gref;
         // Fill 1x1 holes
         for (int x = 2 * brushSize; x >= 0; x--) {
             for (int y = 2 * brushSize; y >= 0; y--) {
@@ -190,20 +175,20 @@ public class SplatterVoxelDiscBrush extends AbstractPerformerBrush {
 
     @Override
     public void sendInfo(Snipe snipe) {
-        if (this.seedPercent < SEED_PERCENT_MIN || this.seedPercent > SEED_PERCENT_MAX) {
-            this.seedPercent = SEED_PERCENT_DEFAULT;
+        if (this.seedPercent < super.seedPercentMin || this.seedPercent > super.seedPercentMax) {
+            this.seedPercent = getIntegerProperty("default-seed-percent", DEFAULT_SEED_PERCENT);
         }
-        if (this.growPercent < GROW_PERCENT_MIN || this.growPercent > GROW_PERCENT_MAX) {
-            this.growPercent = GROW_PERCENT_DEFAULT;
+        if (this.growthPercent < super.growthPercentMin || this.growthPercent > super.growthPercentMax) {
+            this.growthPercent = getIntegerProperty("default-grow-percent", DEFAULT_GROWTH_PERCENT);
         }
-        if (this.splatterRecursions < SPLATTER_RECURSIONS_PERCENT_MIN || this.splatterRecursions > SPLATTER_RECURSIONS_PERCENT_MAX) {
-            this.splatterRecursions = SPLATTER_RECURSIONS_PERCENT_DEFAULT;
+        if (this.splatterRecursions < super.splatterRecursionsMin || this.splatterRecursions > super.splatterRecursionsMax) {
+            this.splatterRecursions = getIntegerProperty("default-splatter-recursions", DEFAULT_SPLATTER_RECURSIONS);
         }
         snipe.createMessageSender()
                 .brushNameMessage()
                 .brushSizeMessage()
                 .message(ChatColor.BLUE + "Seed percent set to: " + this.seedPercent / 100 + "%")
-                .message(ChatColor.BLUE + "Growth percent set to: " + this.growPercent / 100 + "%")
+                .message(ChatColor.BLUE + "Growth percent set to: " + this.growthPercent / 100 + "%")
                 .message(ChatColor.BLUE + "Recursions set to: " + this.splatterRecursions)
                 .send();
     }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DBrush.java
@@ -14,10 +14,12 @@ import org.bukkit.ChatColor;
 
 public class Rotation2DBrush extends AbstractBrush {
 
-    private int mode;
+    private static final int DEFAULT_ANGLE = 0;
+
     private int brushSize;
     private BlockState[][][] snap;
-    private double angle;
+
+    private double angle = DEFAULT_ANGLE;
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
@@ -47,26 +49,16 @@ public class Rotation2DBrush extends AbstractBrush {
     public void handleArrowAction(Snipe snipe) {
         ToolkitProperties toolkitProperties = snipe.getToolkitProperties();
         this.brushSize = toolkitProperties.getBrushSize();
-        if (this.mode == 0) {
-            getMatrix();
-            rotate();
-        } else {
-            SnipeMessenger messenger = snipe.createMessenger();
-            messenger.sendMessage(ChatColor.RED + "Something went wrong.");
-        }
+        getMatrix();
+        rotate();
     }
 
     @Override
     public void handleGunpowderAction(Snipe snipe) {
         ToolkitProperties toolkitProperties = snipe.getToolkitProperties();
         this.brushSize = toolkitProperties.getBrushSize();
-        if (this.mode == 0) {
-            getMatrix();
-            rotate();
-        } else {
-            SnipeMessenger messenger = snipe.createMessenger();
-            messenger.sendMessage(ChatColor.RED + "Something went wrong.");
-        }
+        getMatrix();
+        rotate();
     }
 
     private void getMatrix() {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DBrush.java
@@ -34,7 +34,7 @@ public class Rotation2DBrush extends AbstractBrush {
                 Double degreesAngle = NumericParser.parseDouble(parameters[0]);
                 if (degreesAngle != null) {
                     this.angle = Math.toRadians(degreesAngle);
-                    messenger.sendMessage(ChatColor.GREEN + "Angle set to " + this.angle + " gradians");
+                    messenger.sendMessage(ChatColor.GREEN + "Angle set to: " + DECIMAL_FORMAT.format(this.angle) + " gradians");
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid number.");
                 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DBrush.java
@@ -27,6 +27,8 @@ public class Rotation2DBrush extends AbstractBrush {
         String firstParameter = parameters[0];
 
         if (firstParameter.equalsIgnoreCase("info")) {
+            messenger.sendMessage(ChatColor.DARK_AQUA + "The gradian is a unit of angle measurement different from the degree. " +
+                    "On average, 180 degrees = " + DECIMAL_FORMAT.format(Math.PI) + " radians.");
             messenger.sendMessage(ChatColor.GOLD + "Rotation2D Brush Parameters:");
             messenger.sendMessage(ChatColor.AQUA + "/b rot2 [n] -- Sets rotation angle to n.");
         } else {
@@ -34,7 +36,8 @@ public class Rotation2DBrush extends AbstractBrush {
                 Double degreesAngle = NumericParser.parseDouble(parameters[0]);
                 if (degreesAngle != null) {
                     this.angle = Math.toRadians(degreesAngle);
-                    messenger.sendMessage(ChatColor.GREEN + "Angle set to: " + DECIMAL_FORMAT.format(this.angle) + " gradians");
+                    messenger.sendMessage(ChatColor.GREEN + "Angle set to: " + DECIMAL_FORMAT.format(this.angle) + " gradians " +
+                            "(" + degreesAngle + " degrees)");
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid number.");
                 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DVerticalBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DVerticalBrush.java
@@ -16,10 +16,12 @@ import org.bukkit.ChatColor;
 // original 2d horizontal brush if you wish to make anything similar to this, and start there. I didn't bother renaming everything.
 public class Rotation2DVerticalBrush extends AbstractBrush {
 
-    private int mode;
+    private static final int DEFAULT_ANGLE = 0;
+
     private int brushSize;
     private BlockState[][][] snap;
-    private double angle;
+
+    private double angle = DEFAULT_ANGLE;
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
@@ -49,26 +51,16 @@ public class Rotation2DVerticalBrush extends AbstractBrush {
     public void handleArrowAction(Snipe snipe) {
         ToolkitProperties toolkitProperties = snipe.getToolkitProperties();
         this.brushSize = toolkitProperties.getBrushSize();
-        if (this.mode == 0) {
-            this.getMatrix();
-            this.rotate();
-        } else {
-            SnipeMessenger messenger = snipe.createMessenger();
-            messenger.sendMessage(ChatColor.RED + "Something went wrong.");
-        }
+        this.getMatrix();
+        this.rotate();
     }
 
     @Override
     public void handleGunpowderAction(Snipe snipe) {
         ToolkitProperties toolkitProperties = snipe.getToolkitProperties();
         this.brushSize = toolkitProperties.getBrushSize();
-        if (this.mode == 0) {
-            this.getMatrix();
-            this.rotate();
-        } else {
-            SnipeMessenger messenger = snipe.createMessenger();
-            messenger.sendMessage(ChatColor.RED + "Something went wrong.");
-        }
+        this.getMatrix();
+        this.rotate();
     }
 
     private void getMatrix() {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DVerticalBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DVerticalBrush.java
@@ -36,7 +36,7 @@ public class Rotation2DVerticalBrush extends AbstractBrush {
                 Double degreesAngle = NumericParser.parseDouble(parameters[0]);
                 if (degreesAngle != null) {
                     this.angle = Math.toRadians(degreesAngle);
-                    messenger.sendMessage(ChatColor.GREEN + "Angle set to " + this.angle + " gradians");
+                    messenger.sendMessage(ChatColor.GREEN + "Angle set to: " + DECIMAL_FORMAT.format(this.angle) + " gradians");
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid number.");
                 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DVerticalBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DVerticalBrush.java
@@ -29,6 +29,8 @@ public class Rotation2DVerticalBrush extends AbstractBrush {
         String firstParameter = parameters[0];
 
         if (firstParameter.equalsIgnoreCase("info")) {
+            messenger.sendMessage(ChatColor.DARK_AQUA + "The gradian is a unit of angle measurement different from the degree. " +
+                    "On average, 180 degrees = " + DECIMAL_FORMAT.format(Math.PI) + " radians.");
             messenger.sendMessage(ChatColor.GOLD + "Rotation2DVertical Brush Parameters:");
             messenger.sendMessage(ChatColor.AQUA + "/b rot2v [n] -- Sets rotation angle to n.");
         } else {
@@ -36,7 +38,8 @@ public class Rotation2DVerticalBrush extends AbstractBrush {
                 Double degreesAngle = NumericParser.parseDouble(parameters[0]);
                 if (degreesAngle != null) {
                     this.angle = Math.toRadians(degreesAngle);
-                    messenger.sendMessage(ChatColor.GREEN + "Angle set to: " + DECIMAL_FORMAT.format(this.angle) + " gradians");
+                    messenger.sendMessage(ChatColor.GREEN + "Angle set to: " + DECIMAL_FORMAT.format(this.angle) + " gradians " +
+                            "(" + degreesAngle + " degrees)");
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid number.");
                 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation3DBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation3DBrush.java
@@ -17,11 +17,16 @@ import java.util.stream.Stream;
 
 public class Rotation3DBrush extends AbstractBrush {
 
+    private static final int DEFAULT_SE_YAW = 0;
+    private static final int DEFAULT_SE_PITCH = 0;
+    private static final int DEFAULT_SE_ROLL = 0;
+
     private int brushSize;
     private BlockState[][][] snap;
-    private double seYaw;
-    private double sePitch;
-    private double seRoll;
+
+    private double seYaw = DEFAULT_SE_YAW;
+    private double sePitch = DEFAULT_SE_PITCH;
+    private double seRoll = DEFAULT_SE_ROLL;
 
     // after all rotations, compare snapshot to new state of world?
     // --> agreed. Do what erode does and store one snapshot with Block pointers and int id of what the block started with, afterwards simply go thru that

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation3DBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation3DBrush.java
@@ -11,6 +11,7 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import com.thevoxelbox.voxelsniper.util.material.Materials;
 import com.thevoxelbox.voxelsniper.util.text.NumericParser;
 import org.bukkit.ChatColor;
+import org.checkerframework.checker.units.qual.degrees;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -38,6 +39,8 @@ public class Rotation3DBrush extends AbstractBrush {
 
         // which way is clockwise is less obvious for roll and pitch... should probably fix that / make it clear
         if (firstParameter.equalsIgnoreCase("info")) {
+            messenger.sendMessage(ChatColor.DARK_AQUA + "The gradian is a unit of angle measurement different from the degree. " +
+                    "On average, 180 degrees = " + DECIMAL_FORMAT.format(Math.PI) + " radians.");
             messenger.sendMessage(ChatColor.GOLD + "Rotate Brush Brush Parameters:");
             messenger.sendMessage(ChatColor.AQUA + "/b rot3 p [n] -- Sets degrees of pitch rotation to n (rotation about the Z" +
                     " axis).");
@@ -47,20 +50,21 @@ public class Rotation3DBrush extends AbstractBrush {
                     " about the Y axis).");
         } else {
             if (parameters.length == 2) {
-                Double value = NumericParser.parseDouble(parameters[1]);
-                if (value != null && value >= 0 && value <= 359) {
+                Double degreesAngle = NumericParser.parseDouble(parameters[1]);
+
+                if (degreesAngle != null && degreesAngle >= 0 && degreesAngle <= 359) {
                     if (firstParameter.equalsIgnoreCase("p")) {
-                        this.sePitch = Math.toRadians(value);
+                        this.sePitch = Math.toRadians(degreesAngle);
                         messenger.sendMessage(ChatColor.AQUA + "Around Z-axis degrees set to: " +
-                                DECIMAL_FORMAT.format(this.sePitch) + " gradians");
+                                DECIMAL_FORMAT.format(this.sePitch) + " gradians (" + degreesAngle + " degrees)");
                     } else if (firstParameter.equalsIgnoreCase("r")) {
-                        this.seRoll = Math.toRadians(value);
+                        this.seRoll = Math.toRadians(degreesAngle);
                         messenger.sendMessage(ChatColor.AQUA + "Around X-axis degrees set to: " +
-                                DECIMAL_FORMAT.format(this.seRoll) + " gradians");
+                                DECIMAL_FORMAT.format(this.seRoll) + " gradians (" + degreesAngle + " degrees)");
                     } else if (firstParameter.equalsIgnoreCase("y")) {
-                        this.seYaw = Math.toRadians(value);
+                        this.seYaw = Math.toRadians(degreesAngle);
                         messenger.sendMessage(ChatColor.AQUA + "Around Y-axis degrees set to: " +
-                                DECIMAL_FORMAT.format(this.seYaw) + " gradians");
+                                DECIMAL_FORMAT.format(this.seYaw) + " gradians (" + degreesAngle + " degrees)");
                     }
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid number! Angles must be from 1-359.");

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation3DBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation3DBrush.java
@@ -11,7 +11,6 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import com.thevoxelbox.voxelsniper.util.material.Materials;
 import com.thevoxelbox.voxelsniper.util.text.NumericParser;
 import org.bukkit.ChatColor;
-import org.checkerframework.checker.units.qual.degrees;
 
 import java.util.List;
 import java.util.stream.Stream;

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation3DBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation3DBrush.java
@@ -51,13 +51,16 @@ public class Rotation3DBrush extends AbstractBrush {
                 if (value != null && value >= 0 && value <= 359) {
                     if (firstParameter.equalsIgnoreCase("p")) {
                         this.sePitch = Math.toRadians(value);
-                        messenger.sendMessage(ChatColor.AQUA + "Around Z-axis degrees set to " + this.sePitch + " gradians");
+                        messenger.sendMessage(ChatColor.AQUA + "Around Z-axis degrees set to: " +
+                                DECIMAL_FORMAT.format(this.sePitch) + " gradians");
                     } else if (firstParameter.equalsIgnoreCase("r")) {
                         this.seRoll = Math.toRadians(value);
-                        messenger.sendMessage(ChatColor.AQUA + "Around X-axis degrees set to " + this.seRoll + " gradians");
+                        messenger.sendMessage(ChatColor.AQUA + "Around X-axis degrees set to: " +
+                                DECIMAL_FORMAT.format(this.seRoll) + " gradians");
                     } else if (firstParameter.equalsIgnoreCase("y")) {
                         this.seYaw = Math.toRadians(value);
-                        messenger.sendMessage(ChatColor.AQUA + "Around Y-axis degrees set to " + this.seYaw + " gradians");
+                        messenger.sendMessage(ChatColor.AQUA + "Around Y-axis degrees set to: " +
+                                DECIMAL_FORMAT.format(this.seYaw) + " gradians");
                     }
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid number! Angles must be from 1-359.");

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/shell/ShellSetBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/shell/ShellSetBrush.java
@@ -72,8 +72,9 @@ public class ShellSetBrush extends AbstractBrush {
             int highY = Math.max(y1, y2);
             int highZ = Math.max(z1, z2);
             int size = Math.abs(highX - lowX) * Math.abs(highZ - lowZ) * Math.abs(highY - lowY);
-            if (size > maxSize) {
-                messenger.sendMessage(ChatColor.RED + "Selection size above hardcoded limit, please use a smaller selection.");
+            if (size > this.maxSize) {
+                messenger.sendMessage(ChatColor.RED + "Selection size above " + this.maxSize + " limit, please use a smaller " +
+                        "selection.");
             } else {
                 List<BlockVector3> blocks = new ArrayList<>(size / 2);
                 for (int y = lowY; y <= highY; y++) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/shell/ShellSetBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/shell/ShellSetBrush.java
@@ -17,6 +17,13 @@ public class ShellSetBrush extends AbstractBrush {
 
     private static final int MAX_SIZE = 5000000;
 
+    private int maxSize;
+
+    @Override
+    public void loadProperties() {
+        this.maxSize = getIntegerProperty("max-size", MAX_SIZE);
+    }
+
     @Nullable
     private BlockVector3 block;
     private World world;
@@ -65,7 +72,7 @@ public class ShellSetBrush extends AbstractBrush {
             int highY = Math.max(y1, y2);
             int highZ = Math.max(z1, z2);
             int size = Math.abs(highX - lowX) * Math.abs(highZ - lowZ) * Math.abs(highY - lowY);
-            if (size > MAX_SIZE) {
+            if (size > maxSize) {
                 messenger.sendMessage(ChatColor.RED + "Selection size above hardcoded limit, please use a smaller selection.");
             } else {
                 List<BlockVector3> blocks = new ArrayList<>(size / 2);

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stamp/CloneStampBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stamp/CloneStampBrush.java
@@ -98,19 +98,26 @@ public class CloneStampBrush extends AbstractStampBrush {
         int yStartingPoint = targetBlockY + toolkitProperties.getCylinderCenter();
         int yEndPoint = targetBlockY + toolkitProperties.getVoxelHeight() + toolkitProperties.getCylinderCenter();
         EditSession editSession = getEditSession();
-        if (yStartingPoint < 0) {
-            yStartingPoint = 0;
+        int minHeight = editSession.getMinY();
+        if (yStartingPoint < minHeight) {
+            yStartingPoint = minHeight;
             messenger.sendMessage(ChatColor.DARK_PURPLE + "Warning: off-world start position.");
-        } else if (yStartingPoint > editSession.getMaxY()) {
-            yStartingPoint = editSession.getMaxY();
-            messenger.sendMessage(ChatColor.DARK_PURPLE + "Warning: off-world start position.");
+        } else {
+            int maxHeight = editSession.getMaxY();
+            if (yStartingPoint > maxHeight) {
+                yStartingPoint = maxHeight;
+                messenger.sendMessage(ChatColor.DARK_PURPLE + "Warning: off-world start position.");
+            }
         }
-        if (yEndPoint < 0) {
-            yEndPoint = 0;
+        if (yEndPoint < minHeight) {
+            yEndPoint = minHeight;
             messenger.sendMessage(ChatColor.DARK_PURPLE + "Warning: off-world end position.");
-        } else if (yEndPoint > editSession.getMaxY()) {
-            yEndPoint = editSession.getMaxY();
-            messenger.sendMessage(ChatColor.DARK_PURPLE + "Warning: off-world end position.");
+        } else {
+            int maxHeight = editSession.getMaxY();
+            if (yEndPoint > maxHeight) {
+                yEndPoint = maxHeight;
+                messenger.sendMessage(ChatColor.DARK_PURPLE + "Warning: off-world end position.");
+            }
         }
         double bSquared = Math.pow(brushSize, 2);
         int targetBlockX = targetBlock.getX();

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stamp/CloneStampBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stamp/CloneStampBrush.java
@@ -16,6 +16,13 @@ import java.util.stream.Stream;
  */
 public class CloneStampBrush extends AbstractStampBrush {
 
+    private static final StampType DEFAULT_STAMP_TYPE = StampType.DEFAULT;
+
+    @Override
+    public void loadProperties() {
+        this.setStamp((StampType) getEnumProperty("default-stamp-type", StampType.class, DEFAULT_STAMP_TYPE));
+    }
+
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stamp/CloneStampBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stamp/CloneStampBrush.java
@@ -58,7 +58,7 @@ public class CloneStampBrush extends AbstractStampBrush {
                     Integer cylinderCenter = NumericParser.parseInteger(parameters[1]);
                     if (cylinderCenter != null) {
                         toolkitProperties.setCylinderCenter(cylinderCenter);
-                        messenger.sendMessage(ChatColor.BLUE + "Center set to " + toolkitProperties.getCylinderCenter());
+                        messenger.sendMessage(ChatColor.BLUE + "Center set to: " + toolkitProperties.getCylinderCenter());
                     } else {
                         messenger.sendMessage(ChatColor.RED + "Invalid number.");
                     }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilBrush.java
@@ -4,7 +4,6 @@ import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
-import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.brush.type.AbstractBrush;
 import com.thevoxelbox.voxelsniper.sniper.snipe.Snipe;
 import com.thevoxelbox.voxelsniper.sniper.snipe.message.SnipeMessenger;
@@ -35,10 +34,11 @@ import java.util.stream.Stream;
  */
 public class StencilBrush extends AbstractBrush {
 
+    private static final int DEFAULT_PASTE_OPTION = 1;
+
     private final int[] firstPoint = new int[3];
     private final int[] secondPoint = new int[3];
     private final int[] pastePoint = new int[3];
-    private byte pasteOption = 1; // 0 = full, 1 = fill, 2 = replace
     private String filename = "NoFileLoaded";
     private short x;
     private short z;
@@ -47,6 +47,13 @@ public class StencilBrush extends AbstractBrush {
     private short zRef;
     private short yRef;
     private byte point = 1;
+
+    private byte pasteOption; // 0 = full, 1 = fill, 2 = replace
+
+    @Override
+    public void loadProperties() {
+        this.pasteOption = (byte) getIntegerProperty("default-paste-option", DEFAULT_PASTE_OPTION);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
@@ -83,7 +90,7 @@ public class StencilBrush extends AbstractBrush {
             this.pasteOption = pasteOption;
             try {
                 this.filename = parameters[1 + pasteParam];
-                File file = new File(VoxelSniperPlugin.getPlugin().getDataFolder() + "/stencils/" + this.filename + ".vstencil");
+                File file = new File(plugin.getDataFolder() + "/stencils/" + this.filename + ".vstencil");
                 if (file.exists()) {
                     messenger.sendMessage(ChatColor.RED + "Stencil '" + this.filename + "' exists and was loaded. Make sure you are using gunpowder if you do not want any chance of overwriting the file.");
                 } else {
@@ -151,7 +158,7 @@ public class StencilBrush extends AbstractBrush {
             messenger.sendMessage(ChatColor.RED + "You did not specify a filename. This is required.");
             return;
         }
-        File file = new File(VoxelSniperPlugin.getPlugin().getDataFolder() + "/stencils/" + this.filename + ".vstencil");
+        File file = new File(plugin.getDataFolder() + "/stencils/" + this.filename + ".vstencil");
         if (file.exists()) {
             try {
                 DataInputStream in = new DataInputStream(new BufferedInputStream(new FileInputStream(file)));
@@ -332,7 +339,7 @@ public class StencilBrush extends AbstractBrush {
 
     private void stencilSave(Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
-        File file = new File(VoxelSniperPlugin.getPlugin().getDataFolder() + "/stencils/" + this.filename + ".vstencil");
+        File file = new File(plugin.getDataFolder() + "/stencils/" + this.filename + ".vstencil");
         try {
             this.x = (short) (Math.abs((this.firstPoint[0] - this.secondPoint[0])) + 1);
             this.z = (short) (Math.abs((this.firstPoint[1] - this.secondPoint[1])) + 1);

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilBrush.java
@@ -53,6 +53,9 @@ public class StencilBrush extends AbstractBrush {
     @Override
     public void loadProperties() {
         this.pasteOption = (byte) getIntegerProperty("default-paste-option", DEFAULT_PASTE_OPTION);
+
+        File dataFolder = new File(PLUGIN_DATA_FOLDER, "/stencils");
+        dataFolder.mkdirs();
     }
 
     @Override
@@ -62,9 +65,9 @@ public class StencilBrush extends AbstractBrush {
 
         if (firstParameter.equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.GOLD + "Stencil Brush Parameters:");
-            messenger.sendMessage(ChatColor.AQUA + "/b st (full|fill|replace) [s] -- Loads the specified stencil s. Allowed " +
-                    "size of stencil is based on rank. Full/fill/replace must come first. Full = paste all blocks, " +
-                    "fill = paste only into air blocks, replace = paste full blocks in only, but replace anything in their way.");
+            messenger.sendMessage(ChatColor.AQUA + "/b st (full|fill|replace) [s] -- Loads the specified stencil s. " +
+                    "Full/fill/replace must come first. Full = paste all blocks, fill = paste only into air blocks, replace = " +
+                    "paste full blocks in only, but replace anything in their way.");
         } else {
             byte pasteOption;
             byte pasteParam;
@@ -78,11 +81,11 @@ public class StencilBrush extends AbstractBrush {
                 pasteOption = 2;
                 pasteParam = 1;
             } else {
-                // Reset to [name] parameter expectsted.
+                // Reset to [s] parameter expected.
                 pasteOption = 1;
                 pasteParam = 0;
             }
-            if (parameters.length != 2 + pasteParam) {
+            if (parameters.length != 1 + pasteParam) {
                 messenger.sendMessage(ChatColor.RED + "Missing arguments, this command expects more.");
                 return;
             }
@@ -90,7 +93,7 @@ public class StencilBrush extends AbstractBrush {
             this.pasteOption = pasteOption;
             try {
                 this.filename = parameters[1 + pasteParam];
-                File file = new File(plugin.getDataFolder() + "/stencils/" + this.filename + ".vstencil");
+                File file = new File(PLUGIN_DATA_FOLDER, "/stencils/" + this.filename + ".vstencil");
                 if (file.exists()) {
                     messenger.sendMessage(ChatColor.RED + "Stencil '" + this.filename + "' exists and was loaded. Make sure you are using gunpowder if you do not want any chance of overwriting the file.");
                 } else {
@@ -158,7 +161,7 @@ public class StencilBrush extends AbstractBrush {
             messenger.sendMessage(ChatColor.RED + "You did not specify a filename. This is required.");
             return;
         }
-        File file = new File(plugin.getDataFolder() + "/stencils/" + this.filename + ".vstencil");
+        File file = new File(PLUGIN_DATA_FOLDER, "/stencils/" + this.filename + ".vstencil");
         if (file.exists()) {
             try {
                 DataInputStream in = new DataInputStream(new BufferedInputStream(new FileInputStream(file)));
@@ -339,7 +342,7 @@ public class StencilBrush extends AbstractBrush {
 
     private void stencilSave(Snipe snipe) {
         SnipeMessenger messenger = snipe.createMessenger();
-        File file = new File(plugin.getDataFolder() + "/stencils/" + this.filename + ".vstencil");
+        File file = new File(PLUGIN_DATA_FOLDER, "/stencils/" + this.filename + ".vstencil");
         try {
             this.x = (short) (Math.abs((this.firstPoint[0] - this.secondPoint[0])) + 1);
             this.z = (short) (Math.abs((this.firstPoint[1] - this.secondPoint[1])) + 1);

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilBrush.java
@@ -92,7 +92,7 @@ public class StencilBrush extends AbstractBrush {
 
             this.pasteOption = pasteOption;
             try {
-                this.filename = parameters[1 + pasteParam];
+                this.filename = parameters[pasteParam];
                 File file = new File(PLUGIN_DATA_FOLDER, "/stencils/" + this.filename + ".vstencil");
                 if (file.exists()) {
                     messenger.sendMessage(ChatColor.RED + "Stencil '" + this.filename + "' exists and was loaded. Make sure you are using gunpowder if you do not want any chance of overwriting the file.");

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilListBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilListBrush.java
@@ -68,7 +68,7 @@ public class StencilListBrush extends AbstractBrush {
                 pasteOption = 2;
                 pasteParam = 1;
             } else {
-                // Reset to [name] parameter expectted
+                // Reset to [s] parameter expected.
                 pasteOption = 1;
                 pasteParam = 0;
             }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilListBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilListBrush.java
@@ -40,6 +40,9 @@ public class StencilListBrush extends AbstractBrush {
     @Override
     public void loadProperties() {
         this.pasteOption = (byte) getIntegerProperty("default-paste-option", DEFAULT_PASTE_OPTION);
+
+        File dataFolder = new File(PLUGIN_DATA_FOLDER, "/stencilLists");
+        dataFolder.mkdirs();
     }
 
     @Override
@@ -65,11 +68,11 @@ public class StencilListBrush extends AbstractBrush {
                 pasteOption = 2;
                 pasteParam = 1;
             } else {
-                // Reset to [name] parameter expectsted.
+                // Reset to [name] parameter expectted
                 pasteOption = 1;
                 pasteParam = 0;
             }
-            if (parameters.length != 2 + pasteParam) {
+            if (parameters.length != 1 + pasteParam) {
                 messenger.sendMessage(ChatColor.RED + "Missing arguments, this command expects more.");
                 return;
             }
@@ -77,7 +80,7 @@ public class StencilListBrush extends AbstractBrush {
             this.pasteOption = pasteOption;
             try {
                 this.filename = parameters[1 + pasteParam];
-                File file = new File(plugin.getDataFolder() + "/stencilLists/" + this.filename + ".txt");
+                File file = new File(PLUGIN_DATA_FOLDER, "/stencilLists/" + this.filename + ".txt");
                 if (file.exists()) {
                     messenger.sendMessage(ChatColor.RED + "Stencil List '" + this.filename + "' exists and was loaded.");
                     readStencilList();
@@ -118,7 +121,7 @@ public class StencilListBrush extends AbstractBrush {
 
     private void readStencilList() {
         stencilList.clear();
-        File file = new File(plugin.getDataFolder() + "/stencilLists/" + this.filename + ".txt");
+        File file = new File(PLUGIN_DATA_FOLDER, "/stencilLists/" + this.filename + ".txt");
         if (file.exists()) {
             try {
                 Scanner scanner = new Scanner(file);
@@ -142,7 +145,7 @@ public class StencilListBrush extends AbstractBrush {
         }
         String stencilName = this.readRandomStencil();
         messenger.sendMessage(stencilName);
-        File file = new File(plugin.getDataFolder() + "/stencils/" + stencilName + ".vstencil");
+        File file = new File(PLUGIN_DATA_FOLDER, "/stencils/" + stencilName + ".vstencil");
         if (file.exists()) {
             try {
                 DataInputStream in = new DataInputStream(new BufferedInputStream(new FileInputStream(file)));
@@ -318,7 +321,7 @@ public class StencilListBrush extends AbstractBrush {
             return;
         }
         String stencilName = this.readRandomStencil();
-        File file = new File(plugin.getDataFolder() + "/stencils/" + stencilName + ".vstencil");
+        File file = new File(PLUGIN_DATA_FOLDER, "/stencils/" + stencilName + ".vstencil");
         if (file.exists()) {
             try {
                 DataInputStream in = new DataInputStream(new BufferedInputStream(new FileInputStream(file)));
@@ -494,7 +497,7 @@ public class StencilListBrush extends AbstractBrush {
             return;
         }
         String stencilName = this.readRandomStencil();
-        File file = new File(plugin.getDataFolder() + "/stencils/" + stencilName + ".vstencil");
+        File file = new File(PLUGIN_DATA_FOLDER, "/stencils/" + stencilName + ".vstencil");
         if (file.exists()) {
             try {
                 DataInputStream in = new DataInputStream(new BufferedInputStream(new FileInputStream(file)));
@@ -678,7 +681,7 @@ public class StencilListBrush extends AbstractBrush {
             return;
         }
         String stencilName = this.readRandomStencil();
-        File file = new File(plugin.getDataFolder() + "/stencils/" + stencilName + ".vstencil");
+        File file = new File(PLUGIN_DATA_FOLDER, "/stencils/" + stencilName + ".vstencil");
         if (file.exists()) {
             try {
                 DataInputStream in = new DataInputStream(new BufferedInputStream(new FileInputStream(file)));

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilListBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilListBrush.java
@@ -3,7 +3,6 @@ package com.thevoxelbox.voxelsniper.brush.type.stencil;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockState;
-import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.brush.type.AbstractBrush;
 import com.thevoxelbox.voxelsniper.sniper.snipe.Snipe;
 import com.thevoxelbox.voxelsniper.sniper.snipe.message.SnipeMessenger;
@@ -25,8 +24,9 @@ import java.util.stream.Stream;
 
 public class StencilListBrush extends AbstractBrush {
 
+    private static final int DEFAULT_PASTE_OPTION = 1;
+
     private final Map<Integer, String> stencilList = new HashMap<>();
-    private byte pasteOption = 1; // 0 = full, 1 = fill, 2 = replace
     private String filename = "NoFileLoaded";
     private short x;
     private short z;
@@ -34,6 +34,13 @@ public class StencilListBrush extends AbstractBrush {
     private short xRef;
     private short zRef;
     private short yRef;
+
+    private byte pasteOption; // 0 = full, 1 = fill, 2 = replace
+
+    @Override
+    public void loadProperties() {
+        this.pasteOption = (byte) getIntegerProperty("default-paste-option", DEFAULT_PASTE_OPTION);
+    }
 
     @Override
     public void handleCommand(String[] parameters, Snipe snipe) {
@@ -70,7 +77,7 @@ public class StencilListBrush extends AbstractBrush {
             this.pasteOption = pasteOption;
             try {
                 this.filename = parameters[1 + pasteParam];
-                File file = new File(VoxelSniperPlugin.getPlugin().getDataFolder() + "/stencilLists/" + this.filename + ".txt");
+                File file = new File(plugin.getDataFolder() + "/stencilLists/" + this.filename + ".txt");
                 if (file.exists()) {
                     messenger.sendMessage(ChatColor.RED + "Stencil List '" + this.filename + "' exists and was loaded.");
                     readStencilList();
@@ -111,7 +118,7 @@ public class StencilListBrush extends AbstractBrush {
 
     private void readStencilList() {
         stencilList.clear();
-        File file = new File(VoxelSniperPlugin.getPlugin().getDataFolder() + "/stencilLists/" + this.filename + ".txt");
+        File file = new File(plugin.getDataFolder() + "/stencilLists/" + this.filename + ".txt");
         if (file.exists()) {
             try {
                 Scanner scanner = new Scanner(file);
@@ -135,7 +142,7 @@ public class StencilListBrush extends AbstractBrush {
         }
         String stencilName = this.readRandomStencil();
         messenger.sendMessage(stencilName);
-        File file = new File(VoxelSniperPlugin.getPlugin().getDataFolder() + "/stencils/" + stencilName + ".vstencil");
+        File file = new File(plugin.getDataFolder() + "/stencils/" + stencilName + ".vstencil");
         if (file.exists()) {
             try {
                 DataInputStream in = new DataInputStream(new BufferedInputStream(new FileInputStream(file)));
@@ -311,7 +318,7 @@ public class StencilListBrush extends AbstractBrush {
             return;
         }
         String stencilName = this.readRandomStencil();
-        File file = new File(VoxelSniperPlugin.getPlugin().getDataFolder() + "/stencils/" + stencilName + ".vstencil");
+        File file = new File(plugin.getDataFolder() + "/stencils/" + stencilName + ".vstencil");
         if (file.exists()) {
             try {
                 DataInputStream in = new DataInputStream(new BufferedInputStream(new FileInputStream(file)));
@@ -487,7 +494,7 @@ public class StencilListBrush extends AbstractBrush {
             return;
         }
         String stencilName = this.readRandomStencil();
-        File file = new File(VoxelSniperPlugin.getPlugin().getDataFolder() + "/stencils/" + stencilName + ".vstencil");
+        File file = new File(plugin.getDataFolder() + "/stencils/" + stencilName + ".vstencil");
         if (file.exists()) {
             try {
                 DataInputStream in = new DataInputStream(new BufferedInputStream(new FileInputStream(file)));
@@ -671,7 +678,7 @@ public class StencilListBrush extends AbstractBrush {
             return;
         }
         String stencilName = this.readRandomStencil();
-        File file = new File(VoxelSniperPlugin.getPlugin().getDataFolder() + "/stencils/" + stencilName + ".vstencil");
+        File file = new File(plugin.getDataFolder() + "/stencils/" + stencilName + ".vstencil");
         if (file.exists()) {
             try {
                 DataInputStream in = new DataInputStream(new BufferedInputStream(new FileInputStream(file)));

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilListBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilListBrush.java
@@ -79,7 +79,7 @@ public class StencilListBrush extends AbstractBrush {
 
             this.pasteOption = pasteOption;
             try {
-                this.filename = parameters[1 + pasteParam];
+                this.filename = parameters[pasteParam];
                 File file = new File(PLUGIN_DATA_FOLDER, "/stencilLists/" + this.filename + ".txt");
                 if (file.exists()) {
                     messenger.sendMessage(ChatColor.RED + "Stencil List '" + this.filename + "' exists and was loaded.");

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/Command.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/Command.java
@@ -7,6 +7,7 @@ import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.List;
 
 public final class Command extends org.bukkit.command.Command {
@@ -54,6 +55,10 @@ public final class Command extends org.bukkit.command.Command {
             @NotNull String[] args,
             @Nullable Location location
     ) {
+        String permission = this.properties.getPermission();
+        if (permission != null && !permission.isEmpty() && !sender.hasPermission(permission)) {
+            return Collections.emptyList();
+        }
         if (this.tabCompleter == null) {
             return super.tabComplete(sender, alias, args, location);
         }

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/Command.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/Command.java
@@ -55,6 +55,10 @@ public final class Command extends org.bukkit.command.Command {
             @NotNull String[] args,
             @Nullable Location location
     ) {
+        Class<? extends CommandSender> senderType = this.properties.getSenderTypeOrDefault();
+        if (!senderType.isInstance(sender)) {
+            return Collections.emptyList();
+        }
         String permission = this.properties.getPermission();
         if (permission != null && !permission.isEmpty() && !sender.hasPermission(permission)) {
             return Collections.emptyList();

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/BrushExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/BrushExecutor.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class BrushExecutor implements CommandExecutor, TabCompleter {
@@ -100,10 +101,12 @@ public class BrushExecutor implements CommandExecutor, TabCompleter {
         if (arguments.length == 1) {
             String argument = arguments[0];
             String argumentLowered = argument.toLowerCase(Locale.ROOT);
-            return this.plugin.getBrushRegistry()
-                    .getBrushesProperties()
-                    .keySet()
-                    .stream()
+            return this.plugin.getBrushRegistry().getBrushesProperties().entrySet().stream()
+                    .filter(entry -> {
+                        String permission = entry.getValue().getPermission();
+                        return permission == null || permission.isEmpty() || sender.hasPermission(permission);
+                    })
+                    .map(Map.Entry::getKey)
                     .filter(brushAlias -> brushAlias.startsWith(argumentLowered))
                     .collect(Collectors.toList());
         }

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/BrushExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/BrushExecutor.java
@@ -64,7 +64,7 @@ public class BrushExecutor implements CommandExecutor, TabCompleter {
         if (brushSize != null) {
             VoxelSniperConfig config = this.plugin.getVoxelSniperConfig();
             int litesniperMaxBrushSize = config.getLitesniperMaxBrushSize();
-            Messenger messenger = new Messenger(sender);
+            Messenger messenger = new Messenger(plugin, sender);
             if (!sender.hasPermission("voxelsniper.ignorelimitations") && brushSize > litesniperMaxBrushSize) {
                 sender.sendMessage("Size is restricted to " + litesniperMaxBrushSize + " for you.");
                 toolkitProperties.setBrushSize(litesniperMaxBrushSize);

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/BrushExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/BrushExecutor.java
@@ -62,11 +62,15 @@ public class BrushExecutor implements CommandExecutor, TabCompleter {
         String firstArgument = arguments[0];
         Integer brushSize = NumericParser.parseInteger(firstArgument);
         if (brushSize != null) {
+            if (brushSize < 0) {
+                sender.sendMessage(ChatColor.RED + "Size must be a positive integer.");
+                return;
+            }
             VoxelSniperConfig config = this.plugin.getVoxelSniperConfig();
             int litesniperMaxBrushSize = config.getLitesniperMaxBrushSize();
             Messenger messenger = new Messenger(plugin, sender);
             if (!sender.hasPermission("voxelsniper.ignorelimitations") && brushSize > litesniperMaxBrushSize) {
-                sender.sendMessage("Size is restricted to " + litesniperMaxBrushSize + " for you.");
+                sender.sendMessage(ChatColor.RED + "Size is restricted to " + litesniperMaxBrushSize + " for you.");
                 toolkitProperties.setBrushSize(litesniperMaxBrushSize);
                 messenger.sendBrushSizeMessage(litesniperMaxBrushSize);
             } else {

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelCenterExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelCenterExecutor.java
@@ -43,7 +43,7 @@ public class VoxelCenterExecutor implements CommandExecutor {
             return;
         }
         toolkitProperties.setCylinderCenter(center);
-        Messenger messenger = new Messenger(sender);
+        Messenger messenger = new Messenger(plugin, sender);
         messenger.sendCylinderCenterMessage(center);
     }
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelExecutor.java
@@ -52,7 +52,7 @@ public class VoxelExecutor implements CommandExecutor, TabCompleter {
         if (toolkitProperties == null) {
             return;
         }
-        Messenger messenger = new Messenger(sender);
+        Messenger messenger = new Messenger(plugin, sender);
         VoxelSniperConfig config = this.plugin.getVoxelSniperConfig();
         List<BlockType> liteSniperRestrictedMaterials = config.getLitesniperRestrictedMaterials();
         if (arguments.length == 0) {
@@ -70,7 +70,7 @@ public class VoxelExecutor implements CommandExecutor, TabCompleter {
                 }
                 if (!sender.hasPermission("voxelsniper.ignorelimitations") && liteSniperRestrictedMaterials.contains(
                         targetBlockType)) {
-                    sender.sendMessage("You are not allowed to use " + targetBlockType.getId() + ".");
+                    sender.sendMessage(ChatColor.RED + "You are not allowed to use " + targetBlockType.getId() + ".");
                     return;
                 }
                 toolkitProperties.setBlockType(targetBlockType);
@@ -81,7 +81,7 @@ public class VoxelExecutor implements CommandExecutor, TabCompleter {
         BlockType blockType = BlockTypes.get(arguments[0].toLowerCase(Locale.ROOT));
         if (blockType != null) {
             if (!sender.hasPermission("voxelsniper.ignorelimitations") && liteSniperRestrictedMaterials.contains(blockType)) {
-                sender.sendMessage("You are not allowed to use " + blockType.getId() + ".");
+                sender.sendMessage(ChatColor.RED + "You are not allowed to use " + blockType.getId() + ".");
                 return;
             }
             toolkitProperties.setBlockType(blockType);

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelHeightExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelHeightExecutor.java
@@ -43,7 +43,7 @@ public class VoxelHeightExecutor implements CommandExecutor {
             return;
         }
         toolkitProperties.setVoxelHeight(height);
-        Messenger messenger = new Messenger(sender);
+        Messenger messenger = new Messenger(plugin, sender);
         messenger.sendVoxelHeightMessage(height);
     }
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelInkExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelInkExecutor.java
@@ -57,7 +57,7 @@ public class VoxelInkExecutor implements CommandExecutor {
         }
         BlockState blockState = BukkitAdapter.adapt(blockData);
         toolkitProperties.setBlockData(blockState);
-        Messenger messenger = new Messenger(sender);
+        Messenger messenger = new Messenger(plugin, sender);
         messenger.sendBlockDataMessage(blockState);
     }
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelInkReplaceExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelInkReplaceExecutor.java
@@ -57,7 +57,7 @@ public class VoxelInkReplaceExecutor implements CommandExecutor {
         }
         BlockState blockState = BukkitAdapter.adapt(blockData);
         toolkitProperties.setReplaceBlockData(blockState);
-        Messenger messenger = new Messenger(sender);
+        Messenger messenger = new Messenger(plugin, sender);
         messenger.sendReplaceBlockDataMessage(blockState);
     }
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelListExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelListExecutor.java
@@ -43,7 +43,7 @@ public class VoxelListExecutor implements CommandExecutor {
         if (toolkitProperties == null) {
             return;
         }
-        Messenger messenger = new Messenger(sender);
+        Messenger messenger = new Messenger(plugin, sender);
         if (arguments.length == 0) {
             BlockTracer blockTracer = toolkitProperties.createBlockTracer(player);
             BlockVector3 targetBlock = blockTracer.getTargetBlock();

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelReplaceExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelReplaceExecutor.java
@@ -51,7 +51,7 @@ public class VoxelReplaceExecutor implements CommandExecutor, TabCompleter {
         if (toolkitProperties == null) {
             return;
         }
-        Messenger messenger = new Messenger(sender);
+        Messenger messenger = new Messenger(plugin, sender);
         if (arguments.length == 0) {
             BlockTracer blockTracer = toolkitProperties.createBlockTracer(player);
             BlockVector3 targetBlock = blockTracer.getTargetBlock();

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelSniperExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelSniperExecutor.java
@@ -113,19 +113,14 @@ public class VoxelSniperExecutor implements CommandExecutor, TabCompleter {
                 sender.sendMessage("FastAsyncVoxelSniper is " + (sniper.isEnabled() ? "enabled" : "disabled"));
                 return;
             } else if (firstArgument.equalsIgnoreCase("info")) {
-                if (sender.hasPermission("voxelsniper.admin")) {
-                    sender.sendMessage(plugin.getDescription().getName() + " version " + plugin.getDescription().getVersion());
-                    sender.sendMessage(plugin.getDescription().getDescription());
-                    sender.sendMessage("Website: " + plugin.getDescription().getWebsite());
-                } else {
-                    sender.sendMessage(ChatColor.RED + "You are not allowed to use this command. You're missing the permission " +
-                            "node 'voxelsniper.admin'");
-                }
+                sender.sendMessage(plugin.getDescription().getName() + " version " + plugin.getDescription().getVersion());
+                sender.sendMessage(plugin.getDescription().getDescription());
+                sender.sendMessage("Website: " + plugin.getDescription().getWebsite());
                 return;
             } else if (firstArgument.equalsIgnoreCase("reload")) {
                 if (sender.hasPermission("voxelsniper.admin")) {
                     plugin.reload();
-                    sender.sendMessage(ChatColor.GREEN + "FastAsyncVoxelSniper reloaded!");
+                    sender.sendMessage(ChatColor.GREEN + "FastAsyncVoxelSniper config reloaded!");
                 } else {
                     sender.sendMessage(ChatColor.RED + "You are not allowed to use this command. You're missing the permission " +
                             "node 'voxelsniper.admin'");

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelSniperExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelSniperExecutor.java
@@ -30,15 +30,12 @@ public class VoxelSniperExecutor implements CommandExecutor, TabCompleter {
     @Override
     public void executeCommand(CommandSender sender, String[] arguments) {
         SniperRegistry sniperRegistry = this.plugin.getSniperRegistry();
-        Player player = (Player) sender;
-        Sniper sniper = sniperRegistry.getSniper(player);
-        if (sniper == null) {
-            return;
-        }
+        Sniper sniper = (sender instanceof Player) ? sniperRegistry.getSniper((Player) sender) : null;
+
         if (arguments.length >= 1) {
             String firstArgument = arguments[0];
             if (firstArgument.equalsIgnoreCase("brushes")) {
-                Toolkit toolkit = sniper.getCurrentToolkit();
+                Toolkit toolkit = sniper == null ? null : sniper.getCurrentToolkit();
                 BrushProperties brushProperties = toolkit == null ? null : toolkit.getCurrentBrushProperties();
                 sender.sendMessage(
                         this.plugin.getBrushRegistry().getBrushesProperties().entrySet().stream()
@@ -51,6 +48,9 @@ public class VoxelSniperExecutor implements CommandExecutor, TabCompleter {
                 );
                 return;
             } else if (firstArgument.equalsIgnoreCase("range")) {
+                if (sniper == null) {
+                    return;
+                }
                 Toolkit toolkit = sniper.getCurrentToolkit();
                 if (toolkit == null) {
                     return;
@@ -101,14 +101,23 @@ public class VoxelSniperExecutor implements CommandExecutor, TabCompleter {
                 );
                 return;
             } else if (firstArgument.equalsIgnoreCase("enable")) {
+                if (sniper == null) {
+                    return;
+                }
                 sniper.setEnabled(true);
                 sender.sendMessage("FastAsyncVoxelSniper is " + (sniper.isEnabled() ? "enabled" : "disabled"));
                 return;
             } else if (firstArgument.equalsIgnoreCase("disable")) {
+                if (sniper == null) {
+                    return;
+                }
                 sniper.setEnabled(false);
                 sender.sendMessage("FastAsyncVoxelSniper is " + (sniper.isEnabled() ? "enabled" : "disabled"));
                 return;
             } else if (firstArgument.equalsIgnoreCase("toggle")) {
+                if (sniper == null) {
+                    return;
+                }
                 sniper.setEnabled(!sniper.isEnabled());
                 sender.sendMessage("FastAsyncVoxelSniper is " + (sniper.isEnabled() ? "enabled" : "disabled"));
                 return;
@@ -127,8 +136,10 @@ public class VoxelSniperExecutor implements CommandExecutor, TabCompleter {
                 }
             }
         }
-        sender.sendMessage(ChatColor.DARK_RED + "FastAsyncVoxelSniper - Current Brush Settings:");
-        sniper.sendInfo(sender);
+        if (sniper != null) {
+            sender.sendMessage(ChatColor.DARK_RED + "FastAsyncVoxelSniper - Current Brush Settings:");
+            sniper.sendInfo(sender);
+        }
     }
 
     @Override

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelSniperExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelSniperExecutor.java
@@ -113,10 +113,23 @@ public class VoxelSniperExecutor implements CommandExecutor, TabCompleter {
                 sender.sendMessage("FastAsyncVoxelSniper is " + (sniper.isEnabled() ? "enabled" : "disabled"));
                 return;
             } else if (firstArgument.equalsIgnoreCase("info")) {
-                sender.sendMessage(plugin.getDescription().getName() + " version " + plugin.getDescription().getVersion());
-                sender.sendMessage(plugin.getDescription().getDescription());
-                sender.sendMessage("Website: " + plugin.getDescription().getWebsite());
+                if (sender.hasPermission("voxelsniper.admin")) {
+                    sender.sendMessage(plugin.getDescription().getName() + " version " + plugin.getDescription().getVersion());
+                    sender.sendMessage(plugin.getDescription().getDescription());
+                    sender.sendMessage("Website: " + plugin.getDescription().getWebsite());
+                } else {
+                    sender.sendMessage(ChatColor.RED + "You are not allowed to use this command. You're missing the permission " +
+                            "node 'voxelsniper.admin'");
+                }
                 return;
+            } else if (firstArgument.equalsIgnoreCase("reload")) {
+                if (sender.hasPermission("voxelsniper.admin")) {
+                    plugin.reload();
+                    sender.sendMessage(ChatColor.GREEN + "Configuration reloaded!");
+                } else {
+                    sender.sendMessage(ChatColor.RED + "You are not allowed to use this command. You're missing the permission " +
+                            "node 'voxelsniper.admin'");
+                }
             }
         }
         sender.sendMessage(ChatColor.DARK_RED + "FastAsyncVoxelSniper - Current Brush Settings:");
@@ -128,7 +141,10 @@ public class VoxelSniperExecutor implements CommandExecutor, TabCompleter {
         if (arguments.length == 1) {
             String argument = arguments[0];
             String argumentLowered = argument.toLowerCase(Locale.ROOT);
-            return Stream.of("brushes", "range", "perf", "perflong", "enable", "info", "disable", "toggle")
+            return Stream.concat(
+                            Stream.of("brushes", "range", "perf", "perflong", "enable", "disable", "toggle"),
+                            sender.hasPermission("voxelsniper.admin") ? Stream.of("info", "reload") : Stream.empty()
+                    )
                     .filter(subCommand -> subCommand.startsWith(argumentLowered))
                     .collect(Collectors.toList());
         }

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelSniperExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelSniperExecutor.java
@@ -137,8 +137,8 @@ public class VoxelSniperExecutor implements CommandExecutor, TabCompleter {
             String argument = arguments[0];
             String argumentLowered = argument.toLowerCase(Locale.ROOT);
             return Stream.concat(
-                            Stream.of("brushes", "range", "perf", "perflong", "enable", "disable", "toggle"),
-                            sender.hasPermission("voxelsniper.admin") ? Stream.of("info", "reload") : Stream.empty()
+                            Stream.of("brushes", "range", "perf", "perflong", "enable", "disable", "toggle", "info"),
+                            sender.hasPermission("voxelsniper.admin") ? Stream.of("reload") : Stream.empty()
                     )
                     .filter(subCommand -> subCommand.startsWith(argumentLowered))
                     .collect(Collectors.toList());

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelSniperExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelSniperExecutor.java
@@ -1,11 +1,9 @@
 package com.thevoxelbox.voxelsniper.command.executor;
 
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
-import com.thevoxelbox.voxelsniper.brush.BrushRegistry;
 import com.thevoxelbox.voxelsniper.brush.property.BrushProperties;
 import com.thevoxelbox.voxelsniper.command.CommandExecutor;
-import com.thevoxelbox.voxelsniper.performer.PerformerRegistry;
-import com.thevoxelbox.voxelsniper.performer.property.PerformerProperties;
+import com.thevoxelbox.voxelsniper.command.TabCompleter;
 import com.thevoxelbox.voxelsniper.sniper.Sniper;
 import com.thevoxelbox.voxelsniper.sniper.SniperRegistry;
 import com.thevoxelbox.voxelsniper.sniper.toolkit.Toolkit;
@@ -15,11 +13,13 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import java.util.Map;
-import java.util.Set;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-public class VoxelSniperExecutor implements CommandExecutor {
+public class VoxelSniperExecutor implements CommandExecutor, TabCompleter {
 
     private final VoxelSniperPlugin plugin;
 
@@ -38,11 +38,17 @@ public class VoxelSniperExecutor implements CommandExecutor {
         if (arguments.length >= 1) {
             String firstArgument = arguments[0];
             if (firstArgument.equalsIgnoreCase("brushes")) {
-                BrushRegistry brushRegistry = this.plugin.getBrushRegistry();
-                Map<String, BrushProperties> brushes = brushRegistry.getBrushesProperties();
-                Set<String> aliases = brushes.keySet();
-                String aliasesString = String.join(", ", aliases);
-                sender.sendMessage(aliasesString);
+                Toolkit toolkit = sniper.getCurrentToolkit();
+                BrushProperties brushProperties = toolkit == null ? null : toolkit.getCurrentBrushProperties();
+                sender.sendMessage(
+                        this.plugin.getBrushRegistry().getBrushesProperties().entrySet().stream()
+                                .map(entry -> (entry.getValue() == brushProperties ? ChatColor.GOLD : ChatColor.GRAY)
+                                        + entry.getKey())
+                                .sorted()
+                                .collect(Collectors.joining(ChatColor.WHITE + ", ",
+                                        ChatColor.AQUA + "Available brushes: ", ""
+                                ))
+                );
                 return;
             } else if (firstArgument.equalsIgnoreCase("range")) {
                 Toolkit toolkit = sniper.getCurrentToolkit();
@@ -55,14 +61,17 @@ public class VoxelSniperExecutor implements CommandExecutor {
                 }
                 if (arguments.length == 2) {
                     Integer range = NumericParser.parseInteger(arguments[1]);
-                    if (range == null) {
-                        sender.sendMessage("Can't parse number.");
+                    if (range != null) {
+                        if (range < 1) {
+                            sender.sendMessage("Values less than 1 are not allowed.");
+                            return;
+                        } else {
+                            toolkitProperties.setBlockTracerRange(range);
+                        }
+                    } else {
+                        sender.sendMessage(ChatColor.RED + "Invalid number.");
                         return;
                     }
-                    if (range < 1) {
-                        sender.sendMessage("Values less than 1 are not allowed.");
-                    }
-                    toolkitProperties.setBlockTracerRange(range);
                 } else {
                     toolkitProperties.setBlockTracerRange(0);
                 }
@@ -72,31 +81,28 @@ public class VoxelSniperExecutor implements CommandExecutor {
                         : "on") + ChatColor.GOLD + ". Range is " + ChatColor.LIGHT_PURPLE + blockTracerRange);
                 return;
             } else if (firstArgument.equalsIgnoreCase("perf")) {
-                PerformerRegistry performerRegistry = this.plugin.getPerformerRegistry();
-                Map<String, PerformerProperties> performerProperties = performerRegistry.getPerformerProperties();
-                Set<String> aliases = performerProperties.keySet();
-                String aliasesString = String.join(", ", aliases);
-                sender.sendMessage(ChatColor.AQUA + "Available performers (abbreviated):");
-                sender.sendMessage(aliasesString);
+                sender.sendMessage(
+                        this.plugin.getPerformerRegistry().getPerformerProperties().keySet().stream()
+                                .map(alias -> ChatColor.GRAY + alias)
+                                .sorted()
+                                .collect(Collectors.joining(ChatColor.WHITE + ", ",
+                                        ChatColor.AQUA + "Available performers (abbreviated): ", ""
+                                ))
+                );
                 return;
             } else if (firstArgument.equalsIgnoreCase("perflong")) {
-                PerformerRegistry performerRegistry = this.plugin.getPerformerRegistry();
-                String names = performerRegistry.getPerformerProperties()
-                        .values()
-                        .stream()
-                        .map(PerformerProperties::getName)
-                        .collect(Collectors.joining(", "));
-                sender.sendMessage(ChatColor.AQUA + "Available performers:");
-                sender.sendMessage(names);
+                sender.sendMessage(
+                        this.plugin.getPerformerRegistry().getPerformerProperties().values().stream()
+                                .map(properties -> ChatColor.GRAY + properties.getName())
+                                .sorted()
+                                .collect(Collectors.joining(ChatColor.WHITE + ", ",
+                                        ChatColor.AQUA + "Available performers: ", ""
+                                ))
+                );
                 return;
             } else if (firstArgument.equalsIgnoreCase("enable")) {
                 sniper.setEnabled(true);
                 sender.sendMessage("FastAsyncVoxelSniper is " + (sniper.isEnabled() ? "enabled" : "disabled"));
-                return;
-            } else if (firstArgument.equalsIgnoreCase("info")) {
-                sender.sendMessage(plugin.getDescription().getName() + " version " + plugin.getDescription().getVersion());
-                sender.sendMessage(plugin.getDescription().getDescription());
-                sender.sendMessage("Website: " + plugin.getDescription().getWebsite());
                 return;
             } else if (firstArgument.equalsIgnoreCase("disable")) {
                 sniper.setEnabled(false);
@@ -106,10 +112,27 @@ public class VoxelSniperExecutor implements CommandExecutor {
                 sniper.setEnabled(!sniper.isEnabled());
                 sender.sendMessage("FastAsyncVoxelSniper is " + (sniper.isEnabled() ? "enabled" : "disabled"));
                 return;
+            } else if (firstArgument.equalsIgnoreCase("info")) {
+                sender.sendMessage(plugin.getDescription().getName() + " version " + plugin.getDescription().getVersion());
+                sender.sendMessage(plugin.getDescription().getDescription());
+                sender.sendMessage("Website: " + plugin.getDescription().getWebsite());
+                return;
             }
         }
         sender.sendMessage(ChatColor.DARK_RED + "FastAsyncVoxelSniper - Current Brush Settings:");
         sniper.sendInfo(sender);
+    }
+
+    @Override
+    public List<String> complete(CommandSender sender, String[] arguments) {
+        if (arguments.length == 1) {
+            String argument = arguments[0];
+            String argumentLowered = argument.toLowerCase(Locale.ROOT);
+            return Stream.of("brushes", "range", "perf", "perflong", "enable", "info", "disable", "toggle")
+                    .filter(subCommand -> subCommand.startsWith(argumentLowered))
+                    .collect(Collectors.toList());
+        }
+        return Collections.emptyList();
     }
 
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelSniperExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelSniperExecutor.java
@@ -125,7 +125,7 @@ public class VoxelSniperExecutor implements CommandExecutor, TabCompleter {
             } else if (firstArgument.equalsIgnoreCase("reload")) {
                 if (sender.hasPermission("voxelsniper.admin")) {
                     plugin.reload();
-                    sender.sendMessage(ChatColor.GREEN + "Configuration reloaded!");
+                    sender.sendMessage(ChatColor.GREEN + "FastAsyncVoxelSniper reloaded!");
                 } else {
                     sender.sendMessage(ChatColor.RED + "You are not allowed to use this command. You're missing the permission " +
                             "node 'voxelsniper.admin'");

--- a/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfig.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfig.java
@@ -21,6 +21,21 @@ public class VoxelSniperConfig {
     private final int defaultCylinderCenter;
     private final Map<String, Map<String, Object>> brushProperties;
 
+
+    /**
+     * Create a new cached voxel configuration, used runtime.
+     *
+     * @param messageOnLoginEnabled         if message on login is enabled
+     * @param defaultBlockMaterial          default block material
+     * @param defaultReplaceBlockMaterial   default replace block material
+     * @param defaultBrushSize              default brush size
+     * @param litesniperMaxBrushSize        litesniper max brush size
+     * @param litesniperRestrictedMaterials litesniper restricted materials
+     * @param brushSizeWarningThreshold     brush size warning threshold
+     * @param defaultVoxelHeight            default voxel height
+     * @param defaultCylinderCenter         default cylinder center
+     * @param brushProperties               brush properties
+     */
     public VoxelSniperConfig(
             boolean messageOnLoginEnabled,
             BlockType defaultBlockMaterial,
@@ -45,46 +60,115 @@ public class VoxelSniperConfig {
         this.brushProperties = brushProperties;
     }
 
+    /**
+     * Return if the login message is enabled.
+     *
+     * @return {@code true} if message on login is enabled, {@code false} otherwise.
+     * @see VoxelSniperConfigLoader#isMessageOnLoginEnabled()
+     */
     public boolean isMessageOnLoginEnabled() {
         return this.messageOnLoginEnabled;
     }
 
+    /**
+     * Return default block type
+     *
+     * @return default type
+     * @see VoxelSniperConfigLoader#getDefaultBlockMaterial()
+     */
     public BlockType getDefaultBlockMaterial() {
         return defaultBlockMaterial;
     }
 
+    /**
+     * Return default replace block type.
+     *
+     * @return default type
+     * @see VoxelSniperConfigLoader#getDefaultReplaceBlockMaterial()
+     */
     public BlockType getDefaultReplaceBlockMaterial() {
         return defaultReplaceBlockMaterial;
     }
 
+    /**
+     * Return default brush size.
+     *
+     * @return default size
+     * @see VoxelSniperConfigLoader#getDefaultBrushSize()
+     */
     public int getDefaultBrushSize() {
         return defaultBrushSize;
     }
 
+    /**
+     * Return maximum size of brushes that LiteSnipers can use.
+     *
+     * @return maximum size
+     * @see VoxelSniperConfigLoader#getLitesniperMaxBrushSize()
+     */
     public int getLitesniperMaxBrushSize() {
         return this.litesniperMaxBrushSize;
     }
 
+    /**
+     * Return List of restricted Litesniper materials.
+     *
+     * @return List of restricted Litesniper materials
+     * @see VoxelSniperConfigLoader#getLitesniperRestrictedMaterials()
+     */
     public List<BlockType> getLitesniperRestrictedMaterials() {
         return this.litesniperRestrictedMaterials;
     }
 
+    /**
+     * Gets brush size warning threshold.
+     *
+     * @return the brush size warning threshold
+     * @see VoxelSniperConfigLoader#getBrushSizeWarningThreshold()
+     */
     public int getBrushSizeWarningThreshold() {
         return brushSizeWarningThreshold;
     }
 
+    /**
+     * Return default voxel height.
+     *
+     * @return default height
+     * @see VoxelSniperConfigLoader#getDefaultVoxelHeight()
+     */
     public int getDefaultVoxelHeight() {
         return defaultVoxelHeight;
     }
 
+    /**
+     * Return default cylinder center.
+     *
+     * @return default center
+     * @see VoxelSniperConfigLoader#getDefaultCylinderCenter()
+     */
     public int getDefaultCylinderCenter() {
         return defaultCylinderCenter;
     }
 
+    /**
+     * Return brush properties.
+     * This Map stores another Map (associating Property -> Value) per brush.
+     *
+     * @return brush properties
+     * @see VoxelSniperConfigLoader#getBrushProperties()
+     */
     public Map<String, Map<String, Object>> getBrushProperties() {
         return brushProperties;
     }
 
+    /**
+     * Force saving a brush property and its value to config.
+     * Used to register missing or fix wrong values.
+     *
+     * @param brush       brush
+     * @param propertyKey property key
+     * @param value       alue
+     */
     public void saveBrushPropertyToConfig(String brush, String propertyKey, Object value) {
         plugin.getConfig().set(VoxelSniperConfigLoader.BRUSH_PROPERTIES + "." + brush + "." + propertyKey, value);
         plugin.saveConfig();

--- a/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfig.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfig.java
@@ -1,10 +1,14 @@
 package com.thevoxelbox.voxelsniper.config;
 
 import com.sk89q.worldedit.world.block.BlockType;
+import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 
 import java.util.List;
+import java.util.Map;
 
 public class VoxelSniperConfig {
+
+    private static final VoxelSniperPlugin plugin = VoxelSniperPlugin.plugin;
 
     private final boolean messageOnLoginEnabled;
     private final BlockType defaultBlockMaterial;
@@ -15,6 +19,7 @@ public class VoxelSniperConfig {
     private final int brushSizeWarningThreshold;
     private final int defaultVoxelHeight;
     private final int defaultCylinderCenter;
+    private final Map<String, Map<String, Object>> brushProperties;
 
     public VoxelSniperConfig(
             boolean messageOnLoginEnabled,
@@ -25,7 +30,8 @@ public class VoxelSniperConfig {
             List<BlockType> litesniperRestrictedMaterials,
             int brushSizeWarningThreshold,
             int defaultVoxelHeight,
-            int defaultCylinderCenter
+            int defaultCylinderCenter,
+            Map<String, Map<String, Object>> brushProperties
     ) {
         this.messageOnLoginEnabled = messageOnLoginEnabled;
         this.defaultBlockMaterial = defaultBlockMaterial;
@@ -36,6 +42,7 @@ public class VoxelSniperConfig {
         this.brushSizeWarningThreshold = brushSizeWarningThreshold;
         this.defaultVoxelHeight = defaultVoxelHeight;
         this.defaultCylinderCenter = defaultCylinderCenter;
+        this.brushProperties = brushProperties;
     }
 
     public boolean isMessageOnLoginEnabled() {
@@ -72,6 +79,15 @@ public class VoxelSniperConfig {
 
     public int getDefaultCylinderCenter() {
         return defaultCylinderCenter;
+    }
+
+    public Map<String, Map<String, Object>> getBrushProperties() {
+        return brushProperties;
+    }
+
+    public void saveBrushPropertyToConfig(String brush, String propertyKey, Object value) {
+        plugin.getConfig().set(VoxelSniperConfigLoader.BRUSH_PROPERTIES + "." + brush + "." + propertyKey, value);
+        plugin.saveConfig();
     }
 
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfig.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfig.java
@@ -7,21 +7,51 @@ import java.util.List;
 public class VoxelSniperConfig {
 
     private final boolean messageOnLoginEnabled;
+    private final BlockType defaultBlockMaterial;
+    private final BlockType defaultReplaceBlockMaterial;
+    private final int defaultBrushSize;
     private final int litesniperMaxBrushSize;
     private final List<BlockType> litesniperRestrictedMaterials;
+    private final int brushSizeWarningThreshold;
+    private final int defaultVoxelHeight;
+    private final int defaultCylinderCenter;
 
     public VoxelSniperConfig(
             boolean messageOnLoginEnabled,
+            BlockType defaultBlockMaterial,
+            BlockType defaultReplaceBlockMaterial,
+            int defaultBrushSize,
             int litesniperMaxBrushSize,
-            List<BlockType> litesniperRestrictedMaterials
+            List<BlockType> litesniperRestrictedMaterials,
+            int brushSizeWarningThreshold,
+            int defaultVoxelHeight,
+            int defaultCylinderCenter
     ) {
         this.messageOnLoginEnabled = messageOnLoginEnabled;
+        this.defaultBlockMaterial = defaultBlockMaterial;
+        this.defaultReplaceBlockMaterial = defaultReplaceBlockMaterial;
+        this.defaultBrushSize = defaultBrushSize;
         this.litesniperMaxBrushSize = litesniperMaxBrushSize;
         this.litesniperRestrictedMaterials = litesniperRestrictedMaterials;
+        this.brushSizeWarningThreshold = brushSizeWarningThreshold;
+        this.defaultVoxelHeight = defaultVoxelHeight;
+        this.defaultCylinderCenter = defaultCylinderCenter;
     }
 
     public boolean isMessageOnLoginEnabled() {
         return this.messageOnLoginEnabled;
+    }
+
+    public BlockType getDefaultBlockMaterial() {
+        return defaultBlockMaterial;
+    }
+
+    public BlockType getDefaultReplaceBlockMaterial() {
+        return defaultReplaceBlockMaterial;
+    }
+
+    public int getDefaultBrushSize() {
+        return defaultBrushSize;
     }
 
     public int getLitesniperMaxBrushSize() {
@@ -30,6 +60,18 @@ public class VoxelSniperConfig {
 
     public List<BlockType> getLitesniperRestrictedMaterials() {
         return this.litesniperRestrictedMaterials;
+    }
+
+    public int getBrushSizeWarningThreshold() {
+        return brushSizeWarningThreshold;
+    }
+
+    public int getDefaultVoxelHeight() {
+        return defaultVoxelHeight;
+    }
+
+    public int getDefaultCylinderCenter() {
+        return defaultCylinderCenter;
     }
 
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
@@ -3,12 +3,10 @@ package com.thevoxelbox.voxelsniper.config;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
-import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -55,8 +53,8 @@ public class VoxelSniperConfigLoader {
     /**
      * Create a new cached voxel configuration loader.
      *
-     * @param plugin plugin instance
-     * @param config configuration that is going to be used.
+     * @param plugin the plugin instance
+     * @param config the configuration that is going to be used.
      */
     public VoxelSniperConfigLoader(VoxelSniperPlugin plugin, FileConfiguration config) {
         this.plugin = plugin;
@@ -67,10 +65,10 @@ public class VoxelSniperConfigLoader {
     /**
      * Update config settings the current config version and apply changes.
      */
-    public void updateConfig() {
+    private void updateConfig() {
         int currentConfigVersion = getConfigVersion();
         if (currentConfigVersion != CONFIG_VERSION_VALUE) {
-            Bukkit.getLogger().warning("Invalid config file found! Trying to apply required changes...");
+            plugin.getLogger().warning("Invalid config file found! Trying to apply required changes...");
             setConfigVersion(CONFIG_VERSION_VALUE);
 
             if (currentConfigVersion < 1) {
@@ -107,7 +105,7 @@ public class VoxelSniperConfigLoader {
             }
 
             plugin.saveConfig();
-            Bukkit.getLogger().info("Your config file is now up-to-date! (v" + CONFIG_VERSION_VALUE + ")");
+            plugin.getLogger().info("Your config file is now up-to-date! (v" + CONFIG_VERSION_VALUE + ")");
         }
 
     }
@@ -117,7 +115,7 @@ public class VoxelSniperConfigLoader {
      *
      * @return current version
      */
-    public int getConfigVersion() {
+    protected int getConfigVersion() {
         return this.config.getInt(CONFIG_VERSION, 0);
     }
 
@@ -126,7 +124,7 @@ public class VoxelSniperConfigLoader {
      *
      * @param version new version
      */
-    public void setConfigVersion(int version) {
+    protected void setConfigVersion(int version) {
         this.config.set(CONFIG_VERSION, version);
     }
 
@@ -144,7 +142,7 @@ public class VoxelSniperConfigLoader {
      *
      * @param enabled Messages on Login enabled
      */
-    public void setMessageOnLoginEnabled(boolean enabled) {
+    protected void setMessageOnLoginEnabled(boolean enabled) {
         this.config.set(MESSAGE_ON_LOGIN_ENABLED, enabled);
     }
 
@@ -168,7 +166,7 @@ public class VoxelSniperConfigLoader {
      *
      * @param blockType default type
      */
-    public void setDefaultBlockMaterial(BlockType blockType) {
+    protected void setDefaultBlockMaterial(BlockType blockType) {
         this.config.set(DEFAULT_BLOCK_MATERIAL, blockType.getId());
     }
 
@@ -192,7 +190,7 @@ public class VoxelSniperConfigLoader {
      *
      * @param blockType default type
      */
-    public void setDefaultReplaceBlockMaterial(BlockType blockType) {
+    protected void setDefaultReplaceBlockMaterial(BlockType blockType) {
         this.config.set(DEFAULT_REPLACE_BLOCK_MATERIAL, blockType.getId());
     }
 
@@ -210,7 +208,7 @@ public class VoxelSniperConfigLoader {
      *
      * @param size default size
      */
-    public void setDefaultBrushSize(int size) {
+    protected void setDefaultBrushSize(int size) {
         this.config.set(DEFAULT_BRUSH_SIZE, size);
     }
 
@@ -228,7 +226,7 @@ public class VoxelSniperConfigLoader {
      *
      * @param size maximum size
      */
-    public void setLitesniperMaxBrushSize(int size) {
+    protected void setLitesniperMaxBrushSize(int size) {
         this.config.set(LITESNIPER_MAX_BRUSH_SIZE, size);
     }
 
@@ -250,7 +248,7 @@ public class VoxelSniperConfigLoader {
      *
      * @param restrictedMaterials List of restricted Litesniper materials
      */
-    public void setLitesniperRestrictedMaterials(List<BlockType> restrictedMaterials) {
+    protected void setLitesniperRestrictedMaterials(List<BlockType> restrictedMaterials) {
         this.config.set(LITESNIPER_RESTRICTED_MATERIALS, restrictedMaterials.stream()
                 .map(BlockType::getId).collect(Collectors.toList()));
     }
@@ -269,7 +267,7 @@ public class VoxelSniperConfigLoader {
      *
      * @param size maximum size
      */
-    public void setBrushSizeWarningThreshold(int size) {
+    protected void setBrushSizeWarningThreshold(int size) {
         this.config.set(BRUSH_SIZE_WARNING_THRESHOLD, size);
     }
 
@@ -287,7 +285,7 @@ public class VoxelSniperConfigLoader {
      *
      * @param height default height
      */
-    public void setDefaultVoxelHeight(int height) {
+    protected void setDefaultVoxelHeight(int height) {
         this.config.set(DEFAULT_VOXEL_HEIGHT, height);
     }
 
@@ -305,7 +303,7 @@ public class VoxelSniperConfigLoader {
      *
      * @param center default center
      */
-    public void setDefaultCylinderCenter(int center) {
+    protected void setDefaultCylinderCenter(int center) {
         this.config.set(DEFAULT_CYLINDER_CENTER, center);
     }
 
@@ -346,7 +344,7 @@ public class VoxelSniperConfigLoader {
      *
      * @param brushProperties brush properties
      */
-    public void setBrushProperties(Map<String, Map<String, Object>> brushProperties) {
+    protected void setBrushProperties(Map<String, Map<String, Object>> brushProperties) {
         for (Map.Entry<String, Map<String, Object>> brushesEntry : brushProperties.entrySet()) {
             String brush = brushesEntry.getKey();
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
@@ -49,7 +49,7 @@ public class VoxelSniperConfigLoader {
     /**
      * Return if the login message is enabled.
      *
-     * @return true if message on login is enabled, false otherwise.
+     * @return {@code true} if message on login is enabled, {@code false} otherwise.
      */
     public boolean isMessageOnLoginEnabled() {
         return this.config.getBoolean(MESSAGE_ON_LOGIN_ENABLED, DEFAULT_MESSAGE_ON_LOGIN_ENABLED);
@@ -65,7 +65,7 @@ public class VoxelSniperConfigLoader {
     }
 
     /**
-     * Return default block material.
+     * Return default block type.
      *
      * @return default type
      */
@@ -80,7 +80,7 @@ public class VoxelSniperConfigLoader {
     }
 
     /**
-     * Set default block material
+     * Set default block type.
      *
      * @param blockType default type
      */
@@ -89,7 +89,7 @@ public class VoxelSniperConfigLoader {
     }
 
     /**
-     * Return default replace block material.
+     * Return default replace block type.
      *
      * @return default type
      */
@@ -104,7 +104,7 @@ public class VoxelSniperConfigLoader {
     }
 
     /**
-     * Set default replace block material
+     * Set default replace block type.
      *
      * @param blockType default type
      */
@@ -149,9 +149,9 @@ public class VoxelSniperConfigLoader {
     }
 
     /**
-     * Return List of restricted Litesniper Materials.
+     * Return List of restricted Litesniper materials.
      *
-     * @return List of restricted Litesniper Materials
+     * @return List of restricted Litesniper materials
      */
     public List<BlockType> getLitesniperRestrictedMaterials() {
         return this.config.getStringList(LITESNIPER_RESTRICTED_MATERIALS).stream()
@@ -162,9 +162,9 @@ public class VoxelSniperConfigLoader {
     }
 
     /**
-     * Set new list of restricted Litesniper Materials.
+     * Set new list of restricted Litesniper materials.
      *
-     * @param restrictedMaterials List of restricted Litesniper Materials
+     * @param restrictedMaterials List of restricted Litesniper materials
      */
     public void setLitesniperRestrictedMaterials(List<BlockType> restrictedMaterials) {
         this.config.set(LITESNIPER_RESTRICTED_MATERIALS, restrictedMaterials.stream()
@@ -227,6 +227,7 @@ public class VoxelSniperConfigLoader {
 
     /**
      * Return brush properties.
+     * This Map stores another Map (associating Property -> Value) per brush.
      *
      * @return brush properties
      */

--- a/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
@@ -1,8 +1,13 @@
 package com.thevoxelbox.voxelsniper.config;
 
+import com.sk89q.worldedit.world.block.BlockType;
+import com.sk89q.worldedit.world.block.BlockTypes;
 import org.bukkit.configuration.file.FileConfiguration;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Configuration storage defining global configurations for VoxelSniper.
@@ -10,10 +15,23 @@ import java.util.List;
 public class VoxelSniperConfigLoader {
 
     private static final String MESSAGE_ON_LOGIN_ENABLED = "message-on-login-enabled";
+    private static final String DEFAULT_BLOCK_MATERIAL = "default-block-material";
+    private static final String DEFAULT_REPLACE_BLOCK_MATERIAL = "default-replace-block-material";
+    private static final String DEFAULT_BRUSH_SIZE = "default-brush-size";
     private static final String LITESNIPER_MAX_BRUSH_SIZE = "litesniper-max-brush-size";
     private static final String LITESNIPER_RESTRICTED_MATERIALS = "litesniper-restricted-materials";
+    private static final String BRUSH_SIZE_WARNING_THRESHOLD = "brush-size-warning-threshold";
+    private static final String DEFAULT_VOXEL_HEIGHT = "default-voxel-height";
+    private static final String DEFAULT_CYLINDER_CENTER = "default-cylinder-center";
+
     private static final boolean DEFAULT_MESSAGE_ON_LOGIN_ENABLED = false;
+    private static final BlockType DEFAULT_BLOCK_MATERIAL_VALUE = BlockTypes.AIR;
+    private static final BlockType DEFAULT_REPLACE_BLOCK_MATERIAL_VALUE = BlockTypes.AIR;
+    private static final int DEFAULT_BRUSH_SIZE_VALUE = 3;
     private static final int DEFAULT_LITESNIPER_MAX_BRUSH_SIZE = 5;
+    private static final int DEFAULT_BRUSH_SIZE_WARNING_THRESHOLD = 20;
+    private static final int DEFAULT_VOXEL_HEIGHT_VALUE = 1;
+    private static final int DEFAULT_CYLINDER_CENTER_VALUE = 0;
 
     private final FileConfiguration config;
 
@@ -25,7 +43,7 @@ public class VoxelSniperConfigLoader {
     }
 
     /**
-     * Returns if the login message is enabled.
+     * Return if the login message is enabled.
      *
      * @return true if message on login is enabled, false otherwise.
      */
@@ -43,7 +61,64 @@ public class VoxelSniperConfigLoader {
     }
 
     /**
-     * Returns maximum size of brushes that LiteSnipers can use.
+     * Return default block material.
+     *
+     * @return default type
+     */
+    public BlockType getDefaultBlockMaterial() {
+        return BlockTypes.get(this.config.getString(DEFAULT_BLOCK_MATERIAL, DEFAULT_BLOCK_MATERIAL_VALUE.getId()));
+    }
+
+    /**
+     * Set default block material
+     *
+     * @param blockType default type
+     */
+    public void setDefaultBlockMaterial(BlockType blockType) {
+        this.config.set(DEFAULT_BLOCK_MATERIAL, blockType.getId());
+    }
+
+    /**
+     * Return default replace block material.
+     *
+     * @return default type
+     */
+    public BlockType getDefaultReplaceBlockMaterial() {
+        return BlockTypes.get(this.config.getString(
+                DEFAULT_REPLACE_BLOCK_MATERIAL,
+                DEFAULT_REPLACE_BLOCK_MATERIAL_VALUE.getId()
+        ));
+    }
+
+    /**
+     * Set default replace block material
+     *
+     * @param blockType default type
+     */
+    public void setDefaultReplaceBlockMaterial(BlockType blockType) {
+        this.config.set(DEFAULT_REPLACE_BLOCK_MATERIAL, blockType.getId());
+    }
+
+    /**
+     * Return default brush size.
+     *
+     * @return default size
+     */
+    public int getDefaultBrushSize() {
+        return this.config.getInt(DEFAULT_BRUSH_SIZE, DEFAULT_BRUSH_SIZE_VALUE);
+    }
+
+    /**
+     * Set default brush size.
+     *
+     * @param size default size
+     */
+    public void setDefaultBrushSize(int size) {
+        this.config.set(DEFAULT_BRUSH_SIZE, size);
+    }
+
+    /**
+     * Return maximum size of brushes that LiteSnipers can use.
      *
      * @return maximum size
      */
@@ -61,12 +136,16 @@ public class VoxelSniperConfigLoader {
     }
 
     /**
-     * Returns List of restricted Litesniper Materials.
+     * Return List of restricted Litesniper Materials.
      *
      * @return List of restricted Litesniper Materials
      */
-    public List<String> getLitesniperRestrictedMaterials() {
-        return this.config.getStringList(LITESNIPER_RESTRICTED_MATERIALS);
+    public List<BlockType> getLitesniperRestrictedMaterials() {
+        return this.config.getStringList(LITESNIPER_RESTRICTED_MATERIALS).stream()
+                .map(key -> key.toLowerCase(Locale.ROOT))
+                .map(BlockTypes::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -74,8 +153,63 @@ public class VoxelSniperConfigLoader {
      *
      * @param restrictedMaterials List of restricted Litesniper Materials
      */
-    public void setLitesniperRestrictedMaterials(List<String> restrictedMaterials) {
-        this.config.set(LITESNIPER_RESTRICTED_MATERIALS, restrictedMaterials);
+    public void setLitesniperRestrictedMaterials(List<BlockType> restrictedMaterials) {
+        this.config.set(LITESNIPER_RESTRICTED_MATERIALS, restrictedMaterials.stream()
+                .map(BlockType::getId));
+    }
+
+    /**
+     * Return maximum reasonable brush size before sending a warning.
+     *
+     * @return maximum size
+     */
+    public int getBrushSizeWarningThreshold() {
+        return this.config.getInt(BRUSH_SIZE_WARNING_THRESHOLD, DEFAULT_BRUSH_SIZE_WARNING_THRESHOLD);
+    }
+
+    /**
+     * Set maximum reasonable brush size before sending a warning.
+     *
+     * @param size maximum size
+     */
+    public void setBrushSizeWarningThreshold(int size) {
+        this.config.set(BRUSH_SIZE_WARNING_THRESHOLD, size);
+    }
+
+    /**
+     * Return default voxel height.
+     *
+     * @return default height
+     */
+    public int getDefaultVoxelHeight() {
+        return this.config.getInt(DEFAULT_VOXEL_HEIGHT, DEFAULT_VOXEL_HEIGHT_VALUE);
+    }
+
+    /**
+     * Set default voxel height.
+     *
+     * @param height default height
+     */
+    public void setDefaultVoxelHeight(int height) {
+        this.config.set(DEFAULT_VOXEL_HEIGHT, height);
+    }
+
+    /**
+     * Return default cylinder center.
+     *
+     * @return default center
+     */
+    public int getDefaultCylinderCenter() {
+        return this.config.getInt(DEFAULT_CYLINDER_CENTER, DEFAULT_CYLINDER_CENTER_VALUE);
+    }
+
+    /**
+     * Set default cylinder center.
+     *
+     * @param center default center
+     */
+    public void setDefaultCylinderCenter(int center) {
+        this.config.set(DEFAULT_CYLINDER_CENTER, center);
     }
 
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/listener/PlayerJoinListener.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/listener/PlayerJoinListener.java
@@ -40,7 +40,6 @@ public class PlayerJoinListener implements Listener<PlayerJoinEvent> {
     }
 
     private Sniper registerNewSniper(UUID uuid, SniperRegistry sniperRegistry) {
-        VoxelSniperConfig config = this.plugin.getVoxelSniperConfig();
         Sniper newSniper = new Sniper(uuid);
         sniperRegistry.register(newSniper);
         return newSniper;

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/Performer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/Performer.java
@@ -2,14 +2,53 @@ package com.thevoxelbox.voxelsniper.performer;
 
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.world.block.BlockState;
+import com.thevoxelbox.voxelsniper.performer.property.PerformerProperties;
 import com.thevoxelbox.voxelsniper.sniper.snipe.performer.PerformerSnipe;
 
 public interface Performer {
 
+    /**
+     * Initialize performer.
+     *
+     * @param snipe Snipe
+     */
     void initialize(PerformerSnipe snipe);
 
+    /**
+     * Perform performer action.
+     *
+     * @param editSession EditSession
+     * @param x           Block x
+     * @param y           Block y
+     * @param z           Block z
+     * @param block       BlockState
+     */
     void perform(EditSession editSession, int x, int y, int z, BlockState block);
 
+    /**
+     * Send performer information.
+     *
+     * @param snipe Snipe
+     */
     void sendInfo(PerformerSnipe snipe);
+
+    /**
+     * Return performer properties.
+     *
+     * @return performer properties
+     */
+    PerformerProperties getProperties();
+
+    /**
+     * Set performer properties.
+     *
+     * @param properties performer properties
+     */
+    void setProperties(PerformerProperties properties);
+
+    /**
+     * Load brush properties.
+     */
+    void loadProperties();
 
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/Performer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/Performer.java
@@ -8,7 +8,7 @@ import com.thevoxelbox.voxelsniper.sniper.snipe.performer.PerformerSnipe;
 public interface Performer {
 
     /**
-     * Initialize performer.
+     * Initialize performer data.
      *
      * @param snipe Snipe
      */

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/AbstractPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/AbstractPerformer.java
@@ -5,22 +5,39 @@ import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.thevoxelbox.voxelsniper.performer.Performer;
+import com.thevoxelbox.voxelsniper.performer.property.PerformerProperties;
 
 public abstract class AbstractPerformer implements Performer {
 
-    public void setBlockType(EditSession editSession, int x, int y, int z, BlockType type) {
+    private PerformerProperties properties;
+
+    protected void setBlockType(EditSession editSession, int x, int y, int z, BlockType type) {
         setBlockData(editSession, x, y, z, type.getDefaultState());
     }
 
-    public void setBlockData(EditSession editSession, int x, int y, int z, BlockState blockState) {
-        try {
-            editSession.setBlock(x, y, z, blockState);
-            if (blockState.getMaterial().isTile()) {
+    protected void setBlockData(EditSession editSession, int x, int y, int z, BlockState blockState) {
+        editSession.setBlock(x, y, z, blockState);
+        if (blockState.getMaterial().isTile()) {
+            try {
                 editSession.setTile(x, y, z, blockState.getMaterial().getDefaultTile());
+            } catch (WorldEditException e) {
+                throw new RuntimeException(e);
             }
-        } catch (WorldEditException e) {
-            throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public PerformerProperties getProperties() {
+        return properties;
+    }
+
+    @Override
+    public void setProperties(final PerformerProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public void loadProperties() {
     }
 
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/AbstractPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/AbstractPerformer.java
@@ -11,11 +11,11 @@ public abstract class AbstractPerformer implements Performer {
 
     private PerformerProperties properties;
 
-    protected void setBlockType(EditSession editSession, int x, int y, int z, BlockType type) {
+    public void setBlockType(EditSession editSession, int x, int y, int z, BlockType type) {
         setBlockData(editSession, x, y, z, type.getDefaultState());
     }
 
-    protected void setBlockData(EditSession editSession, int x, int y, int z, BlockState blockState) {
+    public void setBlockData(EditSession editSession, int x, int y, int z, BlockState blockState) {
         editSession.setBlock(x, y, z, blockState);
         if (blockState.getMaterial().isTile()) {
             try {

--- a/src/main/java/com/thevoxelbox/voxelsniper/sniper/Sniper.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/sniper/Sniper.java
@@ -143,7 +143,8 @@ public class Sniper {
         BrushProperties currentBrushProperties = toolkit.getCurrentBrushProperties();
         String permission = currentBrushProperties.getPermission();
         if (permission != null && !player.hasPermission(permission)) {
-            player.sendMessage("You are not allowed to use this brush. You're missing the permission node '" + permission + "'");
+            player.sendMessage(ChatColor.RED + "You are not allowed to use this brush. You're missing the permission node " +
+                    "'" + permission + "'");
             return false;
         }
         {

--- a/src/main/java/com/thevoxelbox/voxelsniper/sniper/Sniper.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/sniper/Sniper.java
@@ -109,7 +109,7 @@ public class Sniper {
      * @param usedItem         Item in hand of player
      * @param clickedBlock     Block that the player targeted/interacted with
      * @param clickedBlockFace Face of that targeted Block
-     * @return true if command visibly processed, false otherwise.
+     * @return {@code true} if command visibly processed, {@code false} otherwise.
      */
     public boolean snipe(
             Player player,

--- a/src/main/java/com/thevoxelbox/voxelsniper/sniper/snipe/Snipe.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/sniper/snipe/Snipe.java
@@ -17,7 +17,6 @@ public class Snipe {
     private final BrushProperties brushProperties;
     private final Brush brush;
 
-
     public Snipe(
             Sniper sniper,
             Toolkit toolkit,

--- a/src/main/java/com/thevoxelbox/voxelsniper/sniper/snipe/message/SnipeMessenger.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/sniper/snipe/message/SnipeMessenger.java
@@ -2,6 +2,7 @@ package com.thevoxelbox.voxelsniper.sniper.snipe.message;
 
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
+import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.brush.property.BrushProperties;
 import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import com.thevoxelbox.voxelsniper.util.message.Messenger;
@@ -18,7 +19,7 @@ public class SnipeMessenger {
     public SnipeMessenger(ToolkitProperties toolkitProperties, BrushProperties brushProperties, Player player) {
         this.toolkitProperties = toolkitProperties;
         this.brushProperties = brushProperties;
-        this.messenger = new Messenger(player);
+        this.messenger = new Messenger(VoxelSniperPlugin.plugin, player);
     }
 
     public void sendBrushNameMessage() {

--- a/src/main/java/com/thevoxelbox/voxelsniper/sniper/toolkit/Toolkit.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/sniper/toolkit/Toolkit.java
@@ -67,6 +67,8 @@ public class Toolkit {
     private Brush createBrush(BrushProperties properties) {
         BrushCreator creator = properties.getCreator();
         Brush brush = creator.create();
+        brush.setProperties(properties);
+        brush.loadProperties();
         this.brushes.put(properties, brush);
         return brush;
     }

--- a/src/main/java/com/thevoxelbox/voxelsniper/sniper/toolkit/ToolkitProperties.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/sniper/toolkit/ToolkitProperties.java
@@ -2,7 +2,8 @@ package com.thevoxelbox.voxelsniper.sniper.toolkit;
 
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
-import com.sk89q.worldedit.world.block.BlockTypes;
+import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
+import com.thevoxelbox.voxelsniper.config.VoxelSniperConfig;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
@@ -13,11 +14,8 @@ import java.util.List;
 
 public class ToolkitProperties {
 
-    private static final BlockType DEFAULT_BLOCK_MATERIAL = BlockTypes.AIR;
-    private static final BlockType DEFAULT_REPLACE_BLOCK_MATERIAL = BlockTypes.AIR;
-    private static final int DEFAULT_BRUSH_SIZE = 3;
-    private static final int DEFAULT_VOXEL_HEIGHT = 1;
-    private static final int DEFAULT_CYLINDER_CENTER = 0;
+    private static final VoxelSniperPlugin plugin = VoxelSniperPlugin.plugin;
+
     private final List<BlockState> voxelList = new ArrayList<>();
     private BlockState blockData;
     private BlockState replaceBlockData;
@@ -29,29 +27,36 @@ public class ToolkitProperties {
     private boolean lightningEnabled;
 
     public ToolkitProperties() {
-        this.blockData = DEFAULT_BLOCK_MATERIAL.getDefaultState();
-        this.replaceBlockData = DEFAULT_REPLACE_BLOCK_MATERIAL.getDefaultState();
-        this.brushSize = DEFAULT_BRUSH_SIZE;
-        this.voxelHeight = DEFAULT_VOXEL_HEIGHT;
+        VoxelSniperConfig config = plugin.getVoxelSniperConfig();
+
+        this.blockData = config.getDefaultBlockMaterial().getDefaultState();
+        this.replaceBlockData = config.getDefaultBlockMaterial().getDefaultState();
+        this.brushSize = config.getDefaultBrushSize();
+        this.voxelHeight = config.getDefaultVoxelHeight();
+        this.cylinderCenter = config.getDefaultCylinderCenter();
     }
 
     public void reset() {
+        VoxelSniperConfig config = plugin.getVoxelSniperConfig();
+
         resetBlockData();
         resetReplaceBlockData();
-        this.brushSize = DEFAULT_BRUSH_SIZE;
-        this.voxelHeight = DEFAULT_VOXEL_HEIGHT;
-        this.cylinderCenter = DEFAULT_CYLINDER_CENTER;
+        this.brushSize = config.getDefaultBrushSize();
+        this.voxelHeight = config.getDefaultVoxelHeight();
+        this.cylinderCenter = config.getDefaultCylinderCenter();
         this.blockTracerRange = null;
         this.lightningEnabled = false;
         this.voxelList.clear();
     }
 
     public void resetBlockData() {
-        this.blockData = DEFAULT_BLOCK_MATERIAL.getDefaultState();
+        VoxelSniperConfig config = plugin.getVoxelSniperConfig();
+        this.blockData = config.getDefaultBlockMaterial().getDefaultState();
     }
 
     public void resetReplaceBlockData() {
-        this.replaceBlockData = DEFAULT_REPLACE_BLOCK_MATERIAL.getDefaultState();
+        VoxelSniperConfig config = plugin.getVoxelSniperConfig();
+        this.replaceBlockData = config.getDefaultBlockMaterial().getDefaultState();
     }
 
     public BlockType getBlockType() {

--- a/src/main/java/com/thevoxelbox/voxelsniper/sniper/toolkit/ToolkitProperties.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/sniper/toolkit/ToolkitProperties.java
@@ -30,7 +30,7 @@ public class ToolkitProperties {
         VoxelSniperConfig config = plugin.getVoxelSniperConfig();
 
         this.blockData = config.getDefaultBlockMaterial().getDefaultState();
-        this.replaceBlockData = config.getDefaultBlockMaterial().getDefaultState();
+        this.replaceBlockData = config.getDefaultReplaceBlockMaterial().getDefaultState();
         this.brushSize = config.getDefaultBrushSize();
         this.voxelHeight = config.getDefaultVoxelHeight();
         this.cylinderCenter = config.getDefaultCylinderCenter();
@@ -56,7 +56,7 @@ public class ToolkitProperties {
 
     public void resetReplaceBlockData() {
         VoxelSniperConfig config = plugin.getVoxelSniperConfig();
-        this.replaceBlockData = config.getDefaultBlockMaterial().getDefaultState();
+        this.replaceBlockData = config.getDefaultReplaceBlockMaterial().getDefaultState();
     }
 
     public BlockType getBlockType() {

--- a/src/main/java/com/thevoxelbox/voxelsniper/util/message/MessageSender.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/util/message/MessageSender.java
@@ -1,7 +1,6 @@
 package com.thevoxelbox.voxelsniper.util.message;
 
 import com.sk89q.worldedit.world.block.BlockState;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockType;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -74,9 +73,10 @@ public class MessageSender {
             this.messages.add(ChatColor.DARK_GREEN + "No blocks selected!");
         }
         String message = voxelList.stream()
-                .map(BlockStateHolder::getAsString)
-                .map(dataAsString -> dataAsString + " ")
-                .collect(Collectors.joining("", ChatColor.DARK_GREEN + "Block Types Selected: " + ChatColor.AQUA, ""));
+                .map(state -> ChatColor.AQUA + state.getAsString())
+                .collect(Collectors.joining(ChatColor.WHITE + ", ",
+                        ChatColor.DARK_GREEN + "Block Types Selected: ", ""
+                ));
         this.messages.add(message);
         return this;
     }

--- a/src/main/java/com/thevoxelbox/voxelsniper/util/message/MessageSender.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/util/message/MessageSender.java
@@ -2,6 +2,7 @@ package com.thevoxelbox.voxelsniper.util.message;
 
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
+import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
@@ -11,12 +12,12 @@ import java.util.stream.Collectors;
 
 public class MessageSender {
 
-    private static final int BRUSH_SIZE_WARNING_THRESHOLD = 20;
-
+    private final VoxelSniperPlugin plugin;
     private final CommandSender sender;
     private final List<String> messages = new ArrayList<>(0);
 
     public MessageSender(CommandSender sender) {
+        this.plugin = VoxelSniperPlugin.plugin;
         this.sender = sender;
     }
 
@@ -52,7 +53,7 @@ public class MessageSender {
 
     public MessageSender brushSizeMessage(int brushSize) {
         this.messages.add(ChatColor.GREEN + "Brush Size: " + ChatColor.DARK_RED + brushSize);
-        if (brushSize >= BRUSH_SIZE_WARNING_THRESHOLD) {
+        if (brushSize >= this.plugin.getVoxelSniperConfig().getBrushSizeWarningThreshold()) {
             this.messages.add(ChatColor.RED + "WARNING: Large brush size selected!");
         }
         return this;

--- a/src/main/java/com/thevoxelbox/voxelsniper/util/message/Messenger.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/util/message/Messenger.java
@@ -2,6 +2,7 @@ package com.thevoxelbox.voxelsniper.util.message;
 
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
+import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
@@ -10,11 +11,11 @@ import java.util.stream.Collectors;
 
 public class Messenger {
 
-    private static final int BRUSH_SIZE_WARNING_THRESHOLD = 20;
-
+    private final VoxelSniperPlugin plugin;
     private final CommandSender sender;
 
-    public Messenger(CommandSender sender) {
+    public Messenger(VoxelSniperPlugin plugin, CommandSender sender) {
+        this.plugin = plugin;
         this.sender = sender;
     }
 
@@ -44,7 +45,7 @@ public class Messenger {
 
     public void sendBrushSizeMessage(int brushSize) {
         sendMessage(ChatColor.GREEN + "Brush Size: " + ChatColor.DARK_RED + brushSize);
-        if (brushSize >= BRUSH_SIZE_WARNING_THRESHOLD) {
+        if (brushSize >= this.plugin.getVoxelSniperConfig().getBrushSizeWarningThreshold()) {
             sendMessage(ChatColor.RED + "WARNING: Large brush size selected!");
         }
     }

--- a/src/main/java/com/thevoxelbox/voxelsniper/util/message/Messenger.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/util/message/Messenger.java
@@ -1,7 +1,6 @@
 package com.thevoxelbox.voxelsniper.util.message;
 
 import com.sk89q.worldedit.world.block.BlockState;
-import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockType;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -63,9 +62,10 @@ public class Messenger {
             sendMessage(ChatColor.DARK_GREEN + "No blocks selected!");
         }
         String message = voxelList.stream()
-                .map(BlockStateHolder::getAsString)
-                .map(dataAsString -> dataAsString + " ")
-                .collect(Collectors.joining("", ChatColor.DARK_GREEN + "Block Types Selected: " + ChatColor.AQUA, ""));
+                .map(state -> ChatColor.AQUA + state.getAsString())
+                .collect(Collectors.joining(ChatColor.WHITE + ", ",
+                        ChatColor.DARK_GREEN + "Block Types Selected: ", ""
+                ));
         sendMessage(message);
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,9 +1,13 @@
+# DON'T MODIFY THIS LINE!
+config-version: 1
 message-on-login-enabled: true
 default-block-material: AIR
 default-replace-block-material: AIR
 default-brush-size: 3
 litesniper-max-brush-size: 5
-litesniper-restricted-materials: []
+litesniper-restricted-materials:
+    - BARRIER
+    - BEDROCK
 brush-size-warning-threshold: 20
 default-voxel-height: 1
 default-cylinder-center: 0
@@ -15,13 +19,13 @@ brush-properties:
         growth-percent-max: 9999
         default-growth-percent: 1000
     Canyon:
-        shift-level-min: 10
+        shift-level-min: -54
         shift-level-max: 60
-        default-y-level: 10
+        default-y-level: -54
     Canyon Selection:
-        shift-level-min: 10
+        shift-level-min: -54
         shift-level-max: 60
-        default-y-level: 10
+        default-y-level: -54
     Clone Stamp:
         default-stamp-type: DEFAULT
     Copy Pasta:
@@ -85,22 +89,34 @@ brush-properties:
     Jockey:
         entity-stack-limit: 50
         default-jockey-type: NORMAL_ALL_ENTITIES
+    Move:
+        max-block-count: 5000000
     Ocean:
         water-level-min: 12
         low-cut-level: 12
-        default-water-lever: 62
+        default-water-lever: 63
     Overlay:
         default-depth: 3
-    Pull:
-        default-pinch: 1
-        default-bubble: 0
     Punish:
         max-random-teleportation-range: 400
         infini-punish-size: -3
         default-punishment: FIRE
         default-punish-level: 10
         default-punish-duration: 60
+    Pull:
+        default-pinch: 1
+        default-bubble: 0
     Ring:
+        seed-percent-min: 1
+        seed-percent-max: 9999
+        growth-percent-min: 1
+        growth-percent-max: 9999
+        splatter-recursions-min: 1
+        splatter-recursions-max: 10
+        default-seed-percent: 1000
+        default-growth-percent: 1000
+        default-splatter-recursions: 3
+    Splatter Ball:
         seed-percent-min: 1
         seed-percent-max: 9999
         growth-percent-min: 1
@@ -114,24 +130,6 @@ brush-properties:
         depth-min: 1
         depth-max: 64
         default-depth: 24
-    Set:
-        selection-size-max: 5000000
-    Shell Set:
-        max-size: 5000000
-    Spiral Staircase:
-        default-stair-type: block
-        default-sdirect: c
-        default-sopen: n
-    Splatter Ball:
-        seed-percent-min: 1
-        seed-percent-max: 9999
-        growth-percent-min: 1
-        growth-percent-max: 9999
-        splatter-recursions-min: 1
-        splatter-recursions-max: 10
-        default-seed-percent: 1000
-        default-growth-percent: 1000
-        default-splatter-recursions: 3
     Splatter Disc:
         seed-percent-min: 1
         seed-percent-max: 9999
@@ -142,6 +140,12 @@ brush-properties:
         default-seed-percent: 1000
         default-growth-percent: 1000
         default-splatter-recursions: 3
+    Set:
+        selection-size-max: 5000000
+    Shell Set:
+        max-size: 5000000
+    Stencil List:
+        default-paste-option: 1
     Splatter Overlay:
         seed-percent-min: 1
         seed-percent-max: 9999
@@ -154,6 +158,10 @@ brush-properties:
         default-splatter-recursions: 3
         default-depth: 3
         default-y-offset: 0
+    Spiral Staircase:
+        default-stair-type: block
+        default-sdirect: c
+        default-sopen: n
     Splatter Voxel:
         seed-percent-min: 1
         seed-percent-max: 9999
@@ -176,11 +184,9 @@ brush-properties:
         default-splatter-recursions: 3
     Stencil:
         default-paste-option: 1
-    Stencil List:
-        default-paste-option: 1
-    Three Point Circle:
-        default-tolerance: DEFAULT
     Tree Snipe:
         default-tree-type: TREE
+    Three Point Circle:
+        default-tolerance: DEFAULT
     Underlay:
         default-depth: 3

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,19 +1,18 @@
-# DON'T MODIFY THIS LINE!
-config-version: 1
+# The config-version line is immutable. Don't change the value, it will reset itself after every reboot.
 message-on-login-enabled: true
-default-block-material: AIR
-default-replace-block-material: AIR
+default-block-material: minecraft:air
+default-replace-block-material: minecraft:air
 default-brush-size: 3
-litesniper-max-brush-size: 5
+litesniper-max-brush-size: 7
 litesniper-restricted-materials:
-    - BARRIER
-    - BEDROCK
-brush-size-warning-threshold: 20
+    - minecraft:barrier
+    - minecraft:bedrock
+brush-size-warning-threshold: 3
 default-voxel-height: 1
 default-cylinder-center: 0
 brush-properties:
     Biome:
-        default-biome-type: PLAINS
+        default-biome-type: minecraft:plains
     Blob:
         growth-percent-min: 1
         growth-percent-max: 9999
@@ -49,7 +48,7 @@ brush-properties:
         default-growth-percent: 1000
         default-splatter-recursions: 3
     Entity:
-        default-entity-type: ZOMBIE
+        default-entity-type: minecraft:zombie
     Entity Removal:
         default-exemptions:
             - org.bukkit.entity.Player

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,3 +7,180 @@ litesniper-restricted-materials: []
 brush-size-warning-threshold: 20
 default-voxel-height: 1
 default-cylinder-center: 0
+brush-properties:
+    Biome:
+        default-biome-type: PLAINS
+    Blob:
+        growth-percent-min: 1
+        growth-percent-max: 9999
+        default-growth-percent: 1000
+    Canyon:
+        shift-level-min: 10
+        shift-level-max: 60
+        default-y-level: 10
+    Canyon Selection:
+        shift-level-min: 10
+        shift-level-max: 60
+        default-y-level: 10
+    Clone Stamp:
+        default-stamp-type: DEFAULT
+    Copy Pasta:
+        block-limit: 10000
+    Ellipse:
+        scl-min: 1
+        scl-max: 9999
+        steps-min: 1
+        steps-max: 2000
+        default-x-scl: 10
+        default-y-scl: 10
+        default-steps: 200
+    Ellipsoid:
+        seed-percent-min: 1
+        seed-percent-max: 9999
+        growth-percent-min: 1
+        growth-percent-max: 9999
+        splatter-recursions-min: 1
+        splatter-recursions-max: 10
+        default-seed-percent: 1000
+        default-growth-percent: 1000
+        default-splatter-recursions: 3
+    Entity:
+        default-entity-type: ZOMBIE
+    Entity Removal:
+        default-exemptions:
+            - org.bukkit.entity.Player
+            - org.bukkit.entity.Hanging
+            - org.bukkit.entity.NPC
+    Flat Ocean:
+        default-water-level: 29
+        default-floor-level: 8
+    Generate Tree:
+        default-leaf-type: minecraft:oak_leaves
+        default-wood-type: minecraft:oak_log
+        default-root-float: false
+        default-start-height: 0
+        default-root-length: 9
+        default-min-roots: 1
+        default-max-roots: 2
+        default-thickness: 1
+        default-slope-chance: 40
+        default-height-min: 14
+        default-height-max: 18
+        default-branch-length: 8
+        default-node-min: 3
+        default-node-max: 4
+    Heat Ray:
+        required-obsidian-density: 0.6
+        required-cobble-density: 0.5
+        required-fire-density: -0.25
+        required-air-density: 0.0
+        default-octaves: 5
+        default-frequency: 1.0
+        default-amplitude: 0.3
+    Jagged Line:
+        recursion-min: 1
+        recursion-max: 10
+        defaut-recursion: 3
+        defaut-spread: 3
+    Jockey:
+        entity-stack-limit: 50
+        default-jockey-type: NORMAL_ALL_ENTITIES
+    Ocean:
+        water-level-min: 12
+        low-cut-level: 12
+        default-water-lever: 62
+    Overlay:
+        default-depth: 3
+    Pull:
+        default-pinch: 1
+        default-bubble: 0
+    Punish:
+        max-random-teleportation-range: 400
+        infini-punish-size: -3
+        default-punishment: FIRE
+        default-punish-level: 10
+        default-punish-duration: 60
+    Ring:
+        seed-percent-min: 1
+        seed-percent-max: 9999
+        growth-percent-min: 1
+        growth-percent-max: 9999
+        splatter-recursions-min: 1
+        splatter-recursions-max: 10
+        default-seed-percent: 1000
+        default-growth-percent: 1000
+        default-splatter-recursions: 3
+    Scanner:
+        depth-min: 1
+        depth-max: 64
+        default-depth: 24
+    Set:
+        selection-size-max: 5000000
+    Shell Set:
+        max-size: 5000000
+    Spiral Staircase:
+        default-stair-type: block
+        default-sdirect: c
+        default-sopen: n
+    Splatter Ball:
+        seed-percent-min: 1
+        seed-percent-max: 9999
+        growth-percent-min: 1
+        growth-percent-max: 9999
+        splatter-recursions-min: 1
+        splatter-recursions-max: 10
+        default-seed-percent: 1000
+        default-growth-percent: 1000
+        default-splatter-recursions: 3
+    Splatter Disc:
+        seed-percent-min: 1
+        seed-percent-max: 9999
+        growth-percent-min: 1
+        growth-percent-max: 9999
+        splatter-recursions-min: 1
+        splatter-recursions-max: 10
+        default-seed-percent: 1000
+        default-growth-percent: 1000
+        default-splatter-recursions: 3
+    Splatter Overlay:
+        seed-percent-min: 1
+        seed-percent-max: 9999
+        growth-percent-min: 1
+        growth-percent-max: 9999
+        splatter-recursions-min: 1
+        splatter-recursions-max: 10
+        default-seed-percent: 1000
+        default-growth-percent: 1000
+        default-splatter-recursions: 3
+        default-depth: 3
+        default-y-offset: 0
+    Splatter Voxel:
+        seed-percent-min: 1
+        seed-percent-max: 9999
+        growth-percent-min: 1
+        growth-percent-max: 9999
+        splatter-recursions-min: 1
+        splatter-recursions-max: 10
+        default-seed-percent: 1000
+        default-growth-percent: 1000
+        default-splatter-recursions: 3
+    Splatter Voxel Disc:
+        seed-percent-min: 1
+        seed-percent-max: 9999
+        growth-percent-min: 1
+        growth-percent-max: 9999
+        splatter-recursions-min: 1
+        splatter-recursions-max: 10
+        default-seed-percent: 1000
+        default-growth-percent: 1000
+        default-splatter-recursions: 3
+    Stencil:
+        default-paste-option: 1
+    Stencil List:
+        default-paste-option: 1
+    Three Point Circle:
+        default-tolerance: DEFAULT
+    Tree Snipe:
+        default-tree-type: TREE
+    Underlay:
+        default-depth: 3

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,9 @@
 message-on-login-enabled: true
+default-block-material: AIR
+default-replace-block-material: AIR
+default-brush-size: 3
 litesniper-max-brush-size: 5
-litesniper-restricted-materials:
+litesniper-restricted-materials: []
+brush-size-warning-threshold: 20
+default-voxel-height: 1
+default-cylinder-center: 0


### PR DESCRIPTION
---

### Get rid of hardcoded world heights

- Fix inability to clamp Y outside of Y 0 -> 256.
- Get rid of hardcoded world heights in brushes.

---

### Fixes and refactoring (deprecated methods, inconsistent format, etc)

- Utilize ``LivingEntity#addPotionEffects`` in PunishBrush, multiple effects of the same type are now supported.
- Propagate a common and _pleasant_ format to messages containing lists.
- Don't tab-complete commands if sender doesn't have the required permission.
- Don't tab-complete brushes the player doesn't have access to.
- Replace useless Bukkit Vectors usage.
- Use ``com.sk89q.worldedit.util.Direction`` instead of direct vectors.
- Fix stencil brushes sometimes failing even with correct arguments.
- Fix scanner brush not scanning towards to right direction.
- Fix error when trying to tab-complete from console.
- Remove hardcoded limits and default values in command messages.
- Create default storage folders on startup, such as stencils and signs.

---

### Major improvements to commands and configuration:

- Add a command to reload config requiring an admin permission ``voxelsniper.admin``.
- Make some general fields configurable, such as default flag size or warning threshold.
- Improve brush scalability adding configurable values AND default-values to some brushes.
- Implement config migration for future changes.
- Informational commands such as /vs brushes, info, perf, perflong or reload are now executable from console and players.
- Add ``BrushProperties`` field to all brush instances, their name and properties should be accessible.

---