### PR TITLE
Add configuration option for session persistance

### DIFF
--- a/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperPlugin.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperPlugin.java
@@ -8,6 +8,7 @@ import com.thevoxelbox.voxelsniper.config.VoxelSniperConfig;
 import com.thevoxelbox.voxelsniper.config.VoxelSniperConfigLoader;
 import com.thevoxelbox.voxelsniper.listener.PlayerInteractListener;
 import com.thevoxelbox.voxelsniper.listener.PlayerJoinListener;
+import com.thevoxelbox.voxelsniper.listener.PlayerQuitListener;
 import com.thevoxelbox.voxelsniper.performer.Performer;
 import com.thevoxelbox.voxelsniper.performer.PerformerRegistry;
 import com.thevoxelbox.voxelsniper.performer.property.PerformerProperties;
@@ -60,6 +61,7 @@ public class VoxelSniperPlugin extends JavaPlugin {
 
         return new VoxelSniperConfig(
                 voxelSniperConfigLoader.isMessageOnLoginEnabled(),
+                voxelSniperConfigLoader.arePersistentSessionsEnabled(),
                 voxelSniperConfigLoader.getDefaultBlockMaterial(),
                 voxelSniperConfigLoader.getDefaultReplaceBlockMaterial(),
                 voxelSniperConfigLoader.getDefaultBrushSize(),
@@ -96,6 +98,7 @@ public class VoxelSniperPlugin extends JavaPlugin {
     private void loadListeners() {
         PluginManager pluginManager = Bukkit.getPluginManager();
         pluginManager.registerEvents(new PlayerJoinListener(this), this);
+        pluginManager.registerEvents(new PlayerQuitListener(this), this);
         pluginManager.registerEvents(new PlayerInteractListener(this), this);
     }
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfig.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfig.java
@@ -11,6 +11,7 @@ public class VoxelSniperConfig {
     private static final VoxelSniperPlugin plugin = VoxelSniperPlugin.plugin;
 
     private final boolean messageOnLoginEnabled;
+    private final boolean persistSessionsOnLogout;
     private final BlockType defaultBlockMaterial;
     private final BlockType defaultReplaceBlockMaterial;
     private final int defaultBrushSize;
@@ -26,6 +27,7 @@ public class VoxelSniperConfig {
      * Create a new cached voxel configuration, used runtime.
      *
      * @param messageOnLoginEnabled         if message on login is enabled
+     * @param persistSessionsOnLogout       if snipers shall be removed on logout
      * @param defaultBlockMaterial          default block material
      * @param defaultReplaceBlockMaterial   default replace block material
      * @param defaultBrushSize              default brush size
@@ -38,6 +40,7 @@ public class VoxelSniperConfig {
      */
     public VoxelSniperConfig(
             boolean messageOnLoginEnabled,
+            boolean persistSessionsOnLogout,
             BlockType defaultBlockMaterial,
             BlockType defaultReplaceBlockMaterial,
             int defaultBrushSize,
@@ -49,6 +52,7 @@ public class VoxelSniperConfig {
             Map<String, Map<String, Object>> brushProperties
     ) {
         this.messageOnLoginEnabled = messageOnLoginEnabled;
+        this.persistSessionsOnLogout = persistSessionsOnLogout;
         this.defaultBlockMaterial = defaultBlockMaterial;
         this.defaultReplaceBlockMaterial = defaultReplaceBlockMaterial;
         this.defaultBrushSize = defaultBrushSize;
@@ -68,6 +72,16 @@ public class VoxelSniperConfig {
      */
     public boolean isMessageOnLoginEnabled() {
         return this.messageOnLoginEnabled;
+    }
+
+    /**
+     * Return if persistent sessions are enabled.
+     *
+     * @return {@code true} if persistent session are enabled, {@code false} otherwise.
+     * @see VoxelSniperConfigLoader#arePersistentSessionsEnabled()
+     */
+    public boolean arePersistentSessionsEnabled() {
+        return this.persistSessionsOnLogout;
     }
 
     /**

--- a/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
@@ -34,7 +34,7 @@ public class VoxelSniperConfigLoader {
     protected static final String BRUSH_PROPERTIES = "brush-properties";
 
     private static final int CONFIG_VERSION_VALUE = 1;
-    private static final boolean DEFAULT_MESSAGE_ON_LOGIN_ENABLED = false;
+    private static final boolean DEFAULT_MESSAGE_ON_LOGIN_ENABLED = true;
     private static final boolean DEFAULT_PERSIST_SESSIONS_ON_LOGOUT = true;
     private static final BlockType DEFAULT_BLOCK_MATERIAL_VALUE = BlockTypes.AIR;
     private static final BlockType DEFAULT_REPLACE_BLOCK_MATERIAL_VALUE = BlockTypes.AIR;

--- a/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
@@ -22,6 +22,7 @@ public class VoxelSniperConfigLoader {
 
     private static final String CONFIG_VERSION = "config-version";
     private static final String MESSAGE_ON_LOGIN_ENABLED = "message-on-login-enabled";
+    private static final String PERSIST_SESSIONS_ON_LOGOUT = "persist-sessions-on-logout";
     private static final String DEFAULT_BLOCK_MATERIAL = "default-block-material";
     private static final String DEFAULT_REPLACE_BLOCK_MATERIAL = "default-replace-block-material";
     private static final String DEFAULT_BRUSH_SIZE = "default-brush-size";
@@ -34,6 +35,7 @@ public class VoxelSniperConfigLoader {
 
     private static final int CONFIG_VERSION_VALUE = 1;
     private static final boolean DEFAULT_MESSAGE_ON_LOGIN_ENABLED = false;
+    private static final boolean DEFAULT_PERSIST_SESSIONS_ON_LOGOUT = true;
     private static final BlockType DEFAULT_BLOCK_MATERIAL_VALUE = BlockTypes.AIR;
     private static final BlockType DEFAULT_REPLACE_BLOCK_MATERIAL_VALUE = BlockTypes.AIR;
     private static final int DEFAULT_BRUSH_SIZE_VALUE = 3;
@@ -144,6 +146,24 @@ public class VoxelSniperConfigLoader {
      */
     protected void setMessageOnLoginEnabled(boolean enabled) {
         this.config.set(MESSAGE_ON_LOGIN_ENABLED, enabled);
+    }
+
+    /**
+     * Return if persistent sessions are enabled.
+     *
+     * @return {@code true} if persistent session are enabled, {@code false} otherwise.
+     */
+    public boolean arePersistentSessionsEnabled() {
+        return this.config.getBoolean(PERSIST_SESSIONS_ON_LOGOUT, DEFAULT_PERSIST_SESSIONS_ON_LOGOUT);
+    }
+
+    /**
+     * Set option for sniping sessions to be persisted on logout or not.
+     *
+     * @param enabled Save sniping session upon logout
+     */
+    protected void setPersistentSessions(boolean enabled) {
+        this.config.set(PERSIST_SESSIONS_ON_LOGOUT, enabled);
     }
 
     /**

--- a/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
@@ -89,7 +89,6 @@ public class VoxelSniperConfigLoader {
                         MESSAGE_ON_LOGIN_ENABLED,
                         DEFAULT_MESSAGE_ON_LOGIN_ENABLED
                 ));
-                setPersistentSessions(arePersistentSessionsEnabled());
                 setDefaultBlockMaterial(getDefaultReplaceBlockMaterial());
                 setDefaultReplaceBlockMaterial(getDefaultReplaceBlockMaterial());
                 setDefaultBrushSize(getDefaultBrushSize());
@@ -105,6 +104,9 @@ public class VoxelSniperConfigLoader {
                 setDefaultVoxelHeight(getDefaultVoxelHeight());
                 setDefaultCylinderCenter(getDefaultCylinderCenter());
                 setBrushProperties(getBrushProperties());
+            }
+            if (currentConfigVersion < 2) {
+                setPersistentSessions(arePersistentSessionsEnabled()); 
             }
 
             plugin.saveConfig();

--- a/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
@@ -89,6 +89,7 @@ public class VoxelSniperConfigLoader {
                         MESSAGE_ON_LOGIN_ENABLED,
                         DEFAULT_MESSAGE_ON_LOGIN_ENABLED
                 ));
+                setPersistentSessions(arePersistentSessionsEnabled());
                 setDefaultBlockMaterial(getDefaultReplaceBlockMaterial());
                 setDefaultReplaceBlockMaterial(getDefaultReplaceBlockMaterial());
                 setDefaultBrushSize(getDefaultBrushSize());

--- a/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
@@ -33,7 +33,7 @@ public class VoxelSniperConfigLoader {
     private static final String DEFAULT_CYLINDER_CENTER = "default-cylinder-center";
     protected static final String BRUSH_PROPERTIES = "brush-properties";
 
-    private static final int CONFIG_VERSION_VALUE = 1;
+    private static final int CONFIG_VERSION_VALUE = 2;
     private static final boolean DEFAULT_MESSAGE_ON_LOGIN_ENABLED = true;
     private static final boolean DEFAULT_PERSIST_SESSIONS_ON_LOGOUT = true;
     private static final BlockType DEFAULT_BLOCK_MATERIAL_VALUE = BlockTypes.AIR;

--- a/src/main/java/com/thevoxelbox/voxelsniper/listener/PlayerQuitListener.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/listener/PlayerQuitListener.java
@@ -1,0 +1,37 @@
+package com.thevoxelbox.voxelsniper.listener;
+
+import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
+import com.thevoxelbox.voxelsniper.config.VoxelSniperConfig;
+import com.thevoxelbox.voxelsniper.sniper.Sniper;
+import com.thevoxelbox.voxelsniper.sniper.SniperRegistry;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+public class PlayerQuitListener implements Listener<PlayerQuitEvent> {
+
+    private final VoxelSniperPlugin plugin;
+
+    public PlayerQuitListener(VoxelSniperPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    @Override
+    public void listen(final PlayerQuitEvent event) {
+        VoxelSniperConfig config = this.plugin.getVoxelSniperConfig();
+        if (!config.arePersistentSessionsEnabled()) {
+            unregisterSniper(event.getPlayer());
+        }
+    }
+
+    private void unregisterSniper(Player player) {
+        SniperRegistry sniperRegistry = this.plugin.getSniperRegistry();
+        Sniper sniper = sniperRegistry.getSniper(player);
+        if (sniper == null) {
+            return;
+        }
+        sniperRegistry.unregister(sniper);
+    }
+
+}

--- a/src/main/java/com/thevoxelbox/voxelsniper/sniper/SniperRegistry.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/sniper/SniperRegistry.java
@@ -17,6 +17,11 @@ public class SniperRegistry {
         this.snipers.put(uuid, sniper);
     }
 
+    public void unregister(Sniper sniper) {
+        UUID uuid = sniper.getUuid();
+        this.snipers.remove(uuid);
+    }
+
     @Nullable
     public Sniper getSniper(Player player) {
         UUID uuid = player.getUniqueId();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,6 @@
 # The config-version line is immutable. Don't change the value, it will reset itself after every reboot.
 message-on-login-enabled: true
+persist-sessions-on-logout: true
 default-block-material: minecraft:air
 default-replace-block-material: minecraft:air
 default-brush-size: 3

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,5 @@
 # The config-version line is immutable. Don't change the value, it will reset itself after every reboot.
+config-version: 2
 message-on-login-enabled: true
 persist-sessions-on-logout: true
 default-block-material: minecraft:air


### PR DESCRIPTION
## Overview
**Fixes #62**

## Description
A configuration option has been added to toggle session/sniper persisting across disconnects. This allows for the issue mentioned in #60 to be fully remedied.

I've tried to stick to the coding style previously used in VoxelSniper, a lot could be inlined or similar. Let me know about any issues or feedback!

## Checklist
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncVoxelSniper/blob/main/CONTRIBUTING.md)
