### PR TITLE
style: Do `.editorconfig` validation on compile time

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.ec4j.gradle.EditorconfigExtension
 
 plugins {
 	java
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.pluginyml)
 	alias(libs.plugins.shadow)
 	alias(libs.plugins.grgit)
+	alias(libs.plugins.editorconfig)
 }
 
 java {
@@ -196,4 +197,12 @@ publishing {
             logger.warn("No nexus repository is added; nexusUsername or nexusPassword is null.")
         }
     }
+}
+
+configure<EditorconfigExtension> {
+    includes = listOf("**/*.java")
+}
+
+tasks.named("build").configure {
+    dependsOn("editorconfigCheck")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ paperlib = "1.0.6"
 shadow = "7.0.0"
 grgit = "4.1.0"
 pluginyml = "0.5.0"
+editorconfig = "0.0.3"
 
 [libraries]
 # Platform expectations
@@ -43,3 +44,4 @@ fawe = ["faweBukkit", "faweCore", "faweLibsCore"]
 shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }
 grgit = { id = "org.ajoberstar.grgit", version.ref = "grgit" }
 pluginyml = { id = "net.minecrell.plugin-yml.bukkit", version.ref = "pluginyml" }
+editorconfig = { id = "org.ec4j.editorconfig", version.ref = "editorconfig" }


### PR DESCRIPTION
The idea is to add some sort of validation level to compile time that verifies if code (additions) match our style in place or not.
Tho, if you have the editor config plugin installed, you can always request a reformat by hand, yet that is very tedious and can be outsourced to compile time.
Note: This PR proposes a possible workflow to achieve that, compiling it based on the time this PR has been risen will inevitably fail due our style violations in the past.