### PR TITLE
fix: Fix Stamp Brush

### DIFF
--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stamp/AbstractStampBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stamp/AbstractStampBrush.java
@@ -79,12 +79,13 @@ public abstract class AbstractStampBrush extends AbstractBrush {
 
     protected void setBlock(StampBrushBlockWrapper blockWrapper) {
         BlockVector3 targetBlock = getTargetBlock();
-        clampY(
+
+        setBlockData(
                 targetBlock.getX() + blockWrapper.getX(),
                 targetBlock.getY() + blockWrapper.getY(),
-                targetBlock.getZ() + blockWrapper.getZ()
+                targetBlock.getZ() + blockWrapper.getZ(),
+                blockWrapper.getBlockData()
         );
-        setBlockData(targetBlock.getX(), targetBlock.getY(), targetBlock.getZ(), blockWrapper.getBlockData());
     }
 
     protected void setBlockFill(StampBrushBlockWrapper blockWrapper) {


### PR DESCRIPTION
## Overview
This PR fixes issue #83, causing the stamp tool to not paste the copied blocks correctly.

## Description
The `setBlock` functionality recently changed, resulting in the call to not properly apply the delta position of the block. This would result in all blocks of the selection being pasted at the location of the target block.

## Checklist
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncVoxelSniper/blob/main/CONTRIBUTING.md)
