### PR TITLE
build: Don't build non shadowed jar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,10 +92,6 @@ tasks {
         opt.links("https://javadoc.io/doc/org.jetbrains/annotations/22.0.0/")
     }
 
-    jar {
-        this.archiveClassifier.set("jar")
-    }
-
     shadowJar {
         this.archiveClassifier.set(null as String?)
         this.archiveFileName.set("${project.name}-${project.version}.${this.archiveExtension.getOrElse("jar")}")


### PR DESCRIPTION
This was originally added to filter shadow components when publishing. I superseded this by switching to adhoc components some time ago.