### PR TITLE
feat: Increase max brush size to a reasonable number

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,7 +9,7 @@ litesniper-max-brush-size: 7
 litesniper-restricted-materials:
     - minecraft:barrier
     - minecraft:bedrock
-brush-size-warning-threshold: 3
+brush-size-warning-threshold: 100
 default-voxel-height: 1
 default-cylinder-center: 0
 brush-properties:


### PR DESCRIPTION
Title says all, I assume something went wrong when moving to the improved config. Especially with Fawe, larger numbers are no issue at all, locking the default warning threshold to 3 sounds unreasonable to me.

CC @Aurelien30000 unless I missed the point of this config option.

Edit: 100 sounds more reasonable, yet I was able to perform a ball brush with a radius of 100 in less than a second, however, I'd advice against higher numbers, especially since there would barely a use case for them.