### PR TITLE
Displays syntax errors in a better way

### DIFF
--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BiomeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BiomeBrush.java
@@ -56,7 +56,7 @@ public class BiomeBrush extends AbstractBrush {
                         this.biomeType = biomeType;
                         messenger.sendMessage(ChatColor.GOLD + "Biome type set to: " + ChatColor.DARK_GREEN + this.biomeType.getId());
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid biome type.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid biome type: " + firstParameter);
                     }
                 }
             } else {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ErodeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ErodeBrush.java
@@ -70,7 +70,7 @@ public class ErodeBrush extends AbstractBrush {
                     messenger.sendMessage(ChatColor.LIGHT_PURPLE + "Brush preset set to: " + preset.getName());
                     return;
                 } catch (IllegalArgumentException exception) {
-                    messenger.sendMessage(ChatColor.RED + "Invalid preset.");
+                    messenger.sendMessage(ChatColor.RED + "Invalid preset: " + preset.getName());
                     return;
                 }
             }
@@ -87,7 +87,7 @@ public class ErodeBrush extends AbstractBrush {
                                 this.currentPreset.getFillRecursion()
                         );
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("e")) {
                     Integer erosionFaces = NumericParser.parseInteger(parameters[1]);
@@ -99,7 +99,7 @@ public class ErodeBrush extends AbstractBrush {
                                 this.currentPreset.getFillRecursion()
                         );
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("F")) {
                     Integer fillRecursion = NumericParser.parseInteger(parameters[1]);
@@ -111,7 +111,7 @@ public class ErodeBrush extends AbstractBrush {
                                 fillRecursion
                         );
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("E")) {
                     Integer erosionRecursion = NumericParser.parseInteger(parameters[1]);
@@ -123,7 +123,7 @@ public class ErodeBrush extends AbstractBrush {
                                 this.currentPreset.getFillRecursion()
                         );
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 }
             } else {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/GenerateTreeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/GenerateTreeBrush.java
@@ -95,8 +95,8 @@ public class GenerateTreeBrush extends AbstractBrush {
         if (firstParameter.equalsIgnoreCase("info")) {
             messenger.sendMessage(ChatColor.GOLD + "This brush takes the following parameters:");
             messenger.sendMessage(ChatColor.AQUA + "/b gt default -- Restores default params.");
-            messenger.sendMessage(ChatColor.AQUA + "/b gt lt [t] -- Sets leaf type to t. (e.g. oak)");
-            messenger.sendMessage(ChatColor.AQUA + "/b gt wt [t] -- Sets wood type to t. (e.g. oak)");
+            messenger.sendMessage(ChatColor.AQUA + "/b gt lt [t] -- Sets leaf type to t. (e.g. oak_leaves)");
+            messenger.sendMessage(ChatColor.AQUA + "/b gt wt [t] -- Sets wood type to t. (e.g. oak_log)");
             messenger.sendMessage(ChatColor.AQUA + "/b gt tt [n] -- Sets tree thickness to n. (whole number)");
             messenger.sendMessage(ChatColor.AQUA + "/b gt rf [true|false] -- Sets root float.");
             messenger.sendMessage(ChatColor.AQUA + "/b gt sh [n] -- Sets starting height to n. (whole number)");
@@ -128,7 +128,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                         this.leafType = leafType;
                         messenger.sendMessage(ChatColor.BLUE + "Leaf Type set to: " + this.leafType.getId());
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid leaf type.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid leaf type: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("wt")) { // Wood Type
                     BlockType woodType = BlockTypes.get(parameters[1]);
@@ -136,7 +136,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                         this.woodType = woodType;
                         messenger.sendMessage(ChatColor.BLUE + "Wood Type set to: " + this.woodType.getId());
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid wood type.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid wood type: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("tt")) { // Tree Thickness
                     Integer thickness = NumericParser.parseInteger(parameters[1]);
@@ -144,7 +144,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                         this.thickness = thickness;
                         messenger.sendMessage(ChatColor.BLUE + "Thickness set to: " + this.thickness);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("rf")) { // Root Float
                     this.rootFloat = Boolean.parseBoolean(parameters[1]);
@@ -155,7 +155,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                         this.startHeight = startHeight;
                         messenger.sendMessage(ChatColor.BLUE + "Starting Height set to: " + this.startHeight);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("rl")) { // Root Length
                     Integer rootLength = NumericParser.parseInteger(parameters[1]);
@@ -163,7 +163,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                         this.rootLength = rootLength;
                         messenger.sendMessage(ChatColor.BLUE + "Root Length set to: " + this.rootLength);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("ts")) { // Trunk Slope Chance
                     Integer slopeChance = NumericParser.parseInteger(parameters[1]);
@@ -171,7 +171,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                         this.slopeChance = slopeChance;
                         messenger.sendMessage(ChatColor.BLUE + "Trunk Slope set to: " + this.slopeChance);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("bl")) { // Branch Length
                     Integer branchLenght = NumericParser.parseInteger(parameters[1]);
@@ -179,7 +179,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                         this.branchLength = branchLenght;
                         messenger.sendMessage(ChatColor.BLUE + "Branch Length set to: " + this.branchLength);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("minr")) { // Minimum Roots
                     Integer minRoots = NumericParser.parseInteger(parameters[1]);
@@ -192,7 +192,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                             messenger.sendMessage(ChatColor.BLUE + "Minimum Roots set to: " + this.minRoots);
                         }
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("maxr")) { // Maximum Roots
                     Integer maxRoots = NumericParser.parseInteger(parameters[1]);
@@ -205,7 +205,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                             messenger.sendMessage(ChatColor.BLUE + "Maximum Roots set to: " + this.maxRoots);
                         }
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("minh")) { // Height Minimum
                     Integer heightMinimum = NumericParser.parseInteger(parameters[1]);
@@ -218,7 +218,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                             messenger.sendMessage(ChatColor.BLUE + "Minimum Height set to: " + this.heightMin);
                         }
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("maxh")) { // Height Maximum
                     Integer heightMaximum = NumericParser.parseInteger(parameters[1]);
@@ -231,7 +231,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                             messenger.sendMessage(ChatColor.BLUE + "Maximum Roots set to: " + this.heightMax);
                         }
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("minl")) { // Leaf Node Min Size
                     Integer nodeMin = NumericParser.parseInteger(parameters[1]);
@@ -239,7 +239,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                         this.nodeMin = nodeMin;
                         messenger.sendMessage(ChatColor.BLUE + "Leaf Min Thickness set to: " + this.nodeMin);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("maxl")) { // Leaf Node Max Size
                     Integer nodeMax = NumericParser.parseInteger(parameters[1]);
@@ -247,7 +247,7 @@ public class GenerateTreeBrush extends AbstractBrush {
                         this.nodeMax = nodeMax;
                         messenger.sendMessage(ChatColor.BLUE + "Leaf Max Thickness set to: " + this.nodeMax);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid brush parameters! Use the \"info\" parameter to display parameter info.");

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityBrush.java
@@ -60,7 +60,7 @@ public class EntityBrush extends AbstractBrush {
                         this.entityType = currentEntity;
                         messenger.sendMessage(ChatColor.GREEN + "Entity type set to: " + ChatColor.DARK_GREEN + this.entityType.getName());
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid entity type.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid entity type: " + firstParameter);
                     }
                 }
             } else {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityRemovalBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityRemovalBrush.java
@@ -86,7 +86,7 @@ public class EntityRemovalBrush extends AbstractBrush {
                         this.exemptions.add(exemptionToAdd);
                         messenger.sendMessage(ChatColor.GREEN + "Added \"" + exemptionToAdd + "\" to entity exemptions list.");
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid entity class.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid entity class: " + exemptionToAdd);
                     }
                 } else if (firstParameter.equalsIgnoreCase("-")) {
                     String exemptionToRemove = parameters[1];

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/EllipseBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/EllipseBrush.java
@@ -80,7 +80,7 @@ public class EllipseBrush extends AbstractPerformerBrush {
                         this.xscl = xscl;
                         messenger.sendMessage(ChatColor.AQUA + "X-scale modifier set to: " + this.xscl);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("y")) {
                     Integer yscl = NumericParser.parseInteger(parameters[1]);
@@ -88,7 +88,7 @@ public class EllipseBrush extends AbstractPerformerBrush {
                         this.yscl = yscl;
                         messenger.sendMessage(ChatColor.AQUA + "Y-scale modifier set to: " + this.yscl);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("t")) {
                     Integer steps = NumericParser.parseInteger(parameters[1]);
@@ -96,7 +96,7 @@ public class EllipseBrush extends AbstractPerformerBrush {
                         this.steps = steps;
                         messenger.sendMessage(ChatColor.AQUA + "Render step number set to: " + this.steps);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number : " + parameters[1]);
                     }
 
                 } else {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/EllipsoidBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/EllipsoidBrush.java
@@ -51,7 +51,7 @@ public class EllipsoidBrush extends AbstractPerformerBrush {
                         this.xRad = xRad;
                         messenger.sendMessage(ChatColor.AQUA + "X radius set to: " + this.xRad);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("y")) {
                     Integer yRad = NumericParser.parseInteger(parameters[1]);
@@ -59,7 +59,7 @@ public class EllipsoidBrush extends AbstractPerformerBrush {
                         this.yRad = yRad;
                         messenger.sendMessage(ChatColor.AQUA + "Y radius set to: " + this.yRad);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("z")) {
                     Integer zRad = NumericParser.parseInteger(parameters[1]);
@@ -67,7 +67,7 @@ public class EllipsoidBrush extends AbstractPerformerBrush {
                         this.zRad = zRad;
                         messenger.sendMessage(ChatColor.AQUA + "Z radius set to: " + this.zRad);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid brush parameters! Use the \"info\" parameter to display parameter info.");

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/PunishBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/PunishBrush.java
@@ -106,7 +106,7 @@ public class PunishBrush extends AbstractPerformerBrush {
                         messenger.sendMessage(ChatColor.AQUA + this.punishment.name()
                                 .toLowerCase(Locale.ROOT) + " punishment selected.");
                     } catch (IllegalArgumentException exception) {
-                        messenger.sendMessage(ChatColor.AQUA + "Invalid Punishment.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid Punishment: " + firstParameter);
                     }
                 }
             } else if (parameters.length == 2) {
@@ -119,7 +119,7 @@ public class PunishBrush extends AbstractPerformerBrush {
                             messenger.sendMessage(ChatColor.AQUA + "Your punishments will now only affect: " + this.punishPlayerName);
                         }
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid player name.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid player name: " + punishPlayerName);
                     }
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid brush parameters! Use the \"info\" parameter to display " +

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/ThreePointCircleBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/ThreePointCircleBrush.java
@@ -66,7 +66,7 @@ public class ThreePointCircleBrush extends AbstractPerformerBrush {
                         messenger.sendMessage(ChatColor.AQUA + "Brush set to: " + this.tolerance.name()
                                 .toLowerCase(Locale.ROOT) + " tolerance.");
                     } catch (IllegalArgumentException exception) {
-                        messenger.sendMessage(ChatColor.RED + "Invalid tolerance.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid tolerance:" + firstParameter);
                     }
                 }
             } else {
@@ -126,7 +126,7 @@ public class ThreePointCircleBrush extends AbstractPerformerBrush {
         // Redundant data check
         if (vectorOne.length() == 0 || vectorTwo.length() == 0 || vectorThree.length() == 0 || vectorOne.angle(vectorTwo) == 0 || vectorOne
                 .angle(vectorThree) == 0 || vectorThree.angle(vectorTwo) == 0) {
-            messenger.sendMessage(ChatColor.RED + "ERROR: Invalid points, try again.");
+            messenger.sendMessage(ChatColor.RED + "Invalid points: " + this.coordinatesOne + ", " + this.coordinatesTwo + ", " + this.coordinatesThree);
             this.coordinatesOne = null;
             this.coordinatesTwo = null;
             this.coordinatesThree = null;

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterOverlayBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterOverlayBrush.java
@@ -76,7 +76,7 @@ public class SplatterOverlayBrush extends AbstractPerformerBrush {
                         this.depth = depth < 1 ? 1 : depth;
                         messenger.sendMessage(ChatColor.AQUA + "Depth set to: " + this.depth);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else if (firstParameter.equalsIgnoreCase("s")) {
                     Integer seedPercent = NumericParser.parseInteger(parameters[1]);
@@ -112,7 +112,7 @@ public class SplatterOverlayBrush extends AbstractPerformerBrush {
                         this.yOffset = yOffset;
                         messenger.sendMessage(ChatColor.AQUA + "Y-Offset set to: " + this.yOffset);
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid brush parameters! Use the \"info\" parameter to display parameter info.");

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DBrush.java
@@ -33,13 +33,13 @@ public class Rotation2DBrush extends AbstractBrush {
             messenger.sendMessage(ChatColor.AQUA + "/b rot2 [n] -- Sets rotation angle to n.");
         } else {
             if (parameters.length == 1) {
-                Double degreesAngle = NumericParser.parseDouble(parameters[0]);
+                Double degreesAngle = NumericParser.parseDouble(firstParameter);
                 if (degreesAngle != null) {
                     this.angle = Math.toRadians(degreesAngle);
                     messenger.sendMessage(ChatColor.GREEN + "Angle set to: " + DECIMAL_FORMAT.format(this.angle) + " gradians " +
                             "(" + degreesAngle + " degrees)");
                 } else {
-                    messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                    messenger.sendMessage(ChatColor.RED + "Invalid number: " + firstParameter);
                 }
             } else {
                 messenger.sendMessage(ChatColor.RED + "Invalid brush parameters length! Use the \"info\" parameter to display " +

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DVerticalBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DVerticalBrush.java
@@ -35,13 +35,13 @@ public class Rotation2DVerticalBrush extends AbstractBrush {
             messenger.sendMessage(ChatColor.AQUA + "/b rot2v [n] -- Sets rotation angle to n.");
         } else {
             if (parameters.length == 1) {
-                Double degreesAngle = NumericParser.parseDouble(parameters[0]);
+                Double degreesAngle = NumericParser.parseDouble(firstParameter);
                 if (degreesAngle != null) {
                     this.angle = Math.toRadians(degreesAngle);
                     messenger.sendMessage(ChatColor.GREEN + "Angle set to: " + DECIMAL_FORMAT.format(this.angle) + " gradians " +
                             "(" + degreesAngle + " degrees)");
                 } else {
-                    messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                    messenger.sendMessage(ChatColor.RED + "Invalid number: " + firstParameter);
                 }
             } else {
                 messenger.sendMessage(ChatColor.RED + "Invalid brush parameters length! Use the \"info\" parameter to display " +

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation3DBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation3DBrush.java
@@ -66,7 +66,7 @@ public class Rotation3DBrush extends AbstractBrush {
                                 DECIMAL_FORMAT.format(this.seYaw) + " gradians (" + degreesAngle + " degrees)");
                     }
                 } else {
-                    messenger.sendMessage(ChatColor.RED + "Invalid number! Angles must be from 1-359.");
+                    messenger.sendMessage(ChatColor.RED + "Invalid number! Angles must be from 1-359. Input provided: " + degreesAngle);
                 }
             } else {
                 messenger.sendMessage(ChatColor.RED + "Invalid brush parameters length! Use the \"info\" parameter to display " +

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stamp/CloneStampBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stamp/CloneStampBrush.java
@@ -60,7 +60,7 @@ public class CloneStampBrush extends AbstractStampBrush {
                         toolkitProperties.setCylinderCenter(cylinderCenter);
                         messenger.sendMessage(ChatColor.BLUE + "Center set to: " + toolkitProperties.getCylinderCenter());
                     } else {
-                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                        messenger.sendMessage(ChatColor.RED + "Invalid number: " + parameters[1]);
                     }
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid brush parameters! Use the \"info\" parameter to display parameter info.");

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/GotoExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/GotoExecutor.java
@@ -19,7 +19,7 @@ public class GotoExecutor implements CommandExecutor {
             x = Integer.parseInt(arguments[0]);
             z = Integer.parseInt(arguments[1]);
         } catch (NumberFormatException | ArrayIndexOutOfBoundsException ignored) {
-            sender.sendMessage(ChatColor.RED + "Invalid syntax. Must be a coordinate");
+            sender.sendMessage(ChatColor.RED + "Invalid syntax. Must be a coordinate, not: " + arguments[0] + ", " + arguments[1]);
             return;
         }
         player.teleport(new Location(world, x, world.getHighestBlockYAt(x, z), z));

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/PaintExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/PaintExecutor.java
@@ -30,7 +30,7 @@ public class PaintExecutor implements CommandExecutor, TabCompleter {
             } else {
                 Art art = Art.getByName(arguments[0]);
                 if (art == null) {
-                    sender.sendMessage(ChatColor.RED + "Invalid art name.");
+                    sender.sendMessage(ChatColor.RED + "Invalid art name: " + arguments[0]);
                     return;
                 }
                 ArtHelper.paint(player, art);

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelCenterExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelCenterExecutor.java
@@ -39,7 +39,7 @@ public class VoxelCenterExecutor implements CommandExecutor {
         try {
             center = Integer.parseInt(arguments[0]);
         } catch (NumberFormatException | ArrayIndexOutOfBoundsException ignored) {
-            sender.sendMessage(ChatColor.RED + "Invalid input. Must be a number.");
+            sender.sendMessage(ChatColor.RED + "Invalid input. Must be a number, not: " + arguments[0]);
             return;
         }
         toolkitProperties.setCylinderCenter(center);

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelExecutor.java
@@ -87,7 +87,7 @@ public class VoxelExecutor implements CommandExecutor, TabCompleter {
             toolkitProperties.setBlockType(blockType);
             messenger.sendBlockTypeMessage(blockType);
         } else {
-            sender.sendMessage(ChatColor.RED + "You have entered an invalid Item name.");
+            sender.sendMessage(ChatColor.RED + "You have entered an invalid item name: " + arguments[0]);
         }
     }
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelHeightExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelHeightExecutor.java
@@ -39,7 +39,7 @@ public class VoxelHeightExecutor implements CommandExecutor {
         try {
             height = Integer.parseInt(arguments[0]);
         } catch (NumberFormatException | ArrayIndexOutOfBoundsException ignored) {
-            sender.sendMessage(ChatColor.RED + "Invalid input. Must be a number.");
+            sender.sendMessage(ChatColor.RED + "Invalid input. Must be a number, not: " + arguments[0]);
             return;
         }
         toolkitProperties.setVoxelHeight(height);

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelReplaceExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelReplaceExecutor.java
@@ -76,7 +76,7 @@ public class VoxelReplaceExecutor implements CommandExecutor, TabCompleter {
             toolkitProperties.setReplaceBlockType(blockType);
             messenger.sendReplaceBlockTypeMessage(blockType);
         } else {
-            sender.sendMessage(ChatColor.RED + "You have entered an invalid Item name.");
+            sender.sendMessage(ChatColor.RED + "You have entered an invalid item name: " + arguments[0]);
         }
     }
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelSniperExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelSniperExecutor.java
@@ -73,7 +73,7 @@ public class VoxelSniperExecutor implements CommandExecutor, TabCompleter {
                             toolkitProperties.setBlockTracerRange(range);
                         }
                     } else {
-                        sender.sendMessage(ChatColor.RED + "Invalid number.");
+                        sender.sendMessage(ChatColor.RED + "Invalid number: " + arguments[1]);
                         return;
                     }
                 } else {


### PR DESCRIPTION
## Description
FAVS swallows command syntax errors and responds with a generic wrong syntax message. This gets difficult to figure out, if you're unfamiliar with each command's syntax. The change proposed mitigates this scenario by pointing out the wrong syntax.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)