### PR TITLE
Added option to disable the update notifications

### DIFF
--- a/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperPlugin.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperPlugin.java
@@ -96,6 +96,7 @@ public class VoxelSniperPlugin extends JavaPlugin {
         VoxelSniperConfigLoader voxelSniperConfigLoader = new VoxelSniperConfigLoader(this, config);
 
         return new VoxelSniperConfig(
+                voxelSniperConfigLoader.areUpdateNotificationsEnabled(),
                 voxelSniperConfigLoader.isMessageOnLoginEnabled(),
                 voxelSniperConfigLoader.arePersistentSessionsEnabled(),
                 voxelSniperConfigLoader.getDefaultBlockMaterial(),

--- a/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperPlugin.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperPlugin.java
@@ -39,6 +39,7 @@ public class VoxelSniperPlugin extends JavaPlugin {
     public static VoxelSniperPlugin plugin;
     public static String newVersionTitle = "";
     public static boolean hasUpdate;
+    public static boolean updateCheckFailed;
     private static String currentVersionTitle = "";
     private BrushRegistry brushRegistry;
     private PerformerRegistry performerRegistry;
@@ -73,7 +74,9 @@ public class VoxelSniperPlugin extends JavaPlugin {
         this.getServer().getScheduler().runTaskTimerAsynchronously(this, () -> {
             try {
                 newVersion = updateCheck(currentVersion);
-                if (newVersion > currentVersion) {
+                if (Double.isNaN(newVersion)) {
+                    updateCheckFailed = true;
+                } else if (newVersion > currentVersion) {
                     hasUpdate = true;
                     LOGGER.info("An update for FastAsyncVoxelSniper is available.");
                     LOGGER.info("You are running version {}, the latest version is {}", currentVersionTitle, newVersionTitle);
@@ -199,7 +202,7 @@ public class VoxelSniperPlugin extends JavaPlugin {
         } catch (IOException ignored) {
             LOGGER.error("Unable to connect to dev.bukkit.org to check for updates. Improper firewall configuration?");
         }
-        return currentVersion;
+        return Double.NaN;
     }
 
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfig.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfig.java
@@ -27,7 +27,7 @@ public class VoxelSniperConfig {
     /**
      * Create a new cached voxel configuration, used runtime.
      *
-     * @oaram updateNotificationsEnabled    if to notify about updates
+     * @param updateNotificationsEnabled    notify whether updates are available or not
      * @param messageOnLoginEnabled         if message on login is enabled
      * @param persistSessionsOnLogout       if snipers shall be removed on logout
      * @param defaultBlockMaterial          default block material

--- a/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfig.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfig.java
@@ -10,6 +10,7 @@ public class VoxelSniperConfig {
 
     private static final VoxelSniperPlugin plugin = VoxelSniperPlugin.plugin;
 
+    private final boolean updateNotificationsEnabled;
     private final boolean messageOnLoginEnabled;
     private final boolean persistSessionsOnLogout;
     private final BlockType defaultBlockMaterial;
@@ -26,6 +27,7 @@ public class VoxelSniperConfig {
     /**
      * Create a new cached voxel configuration, used runtime.
      *
+     * @oaram updateNotificationsEnabled    if to notify about updates
      * @param messageOnLoginEnabled         if message on login is enabled
      * @param persistSessionsOnLogout       if snipers shall be removed on logout
      * @param defaultBlockMaterial          default block material
@@ -39,6 +41,7 @@ public class VoxelSniperConfig {
      * @param brushProperties               brush properties
      */
     public VoxelSniperConfig(
+            boolean updateNotificationsEnabled,
             boolean messageOnLoginEnabled,
             boolean persistSessionsOnLogout,
             BlockType defaultBlockMaterial,
@@ -51,6 +54,7 @@ public class VoxelSniperConfig {
             int defaultCylinderCenter,
             Map<String, Map<String, Object>> brushProperties
     ) {
+        this.updateNotificationsEnabled = updateNotificationsEnabled;
         this.messageOnLoginEnabled = messageOnLoginEnabled;
         this.persistSessionsOnLogout = persistSessionsOnLogout;
         this.defaultBlockMaterial = defaultBlockMaterial;
@@ -62,6 +66,16 @@ public class VoxelSniperConfig {
         this.defaultVoxelHeight = defaultVoxelHeight;
         this.defaultCylinderCenter = defaultCylinderCenter;
         this.brushProperties = brushProperties;
+    }
+
+    /**
+     * Return if update notifications are enabled.
+     *
+     * @return {@code true} if notifications for updates are enabled, {@code false} otherwise.
+     * @see VoxelSniperConfigLoader#areUpdateNotificationsEnabled()
+     */
+    public boolean areUpdateNotificationsEnabled() {
+        return this.updateNotificationsEnabled;
     }
 
     /**

--- a/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
@@ -113,7 +113,7 @@ public class VoxelSniperConfigLoader {
                 setPersistentSessions(arePersistentSessionsEnabled());
             }
             if (currentConfigVersion < 3) {
-                setUpdateNotificationsEnabled(areUpdateNotificationsEnabled());
+                enableUpdateNotifications(areUpdateNotificationsEnabled());
             }
 
             plugin.saveConfig();
@@ -154,7 +154,7 @@ public class VoxelSniperConfigLoader {
      *
      * @param enabled Update notifications enabled
      */
-    protected void setUpdateNotificationsEnabled(boolean enabled) {
+    protected void enableUpdateNotifications(boolean enabled) {
         this.config.set(UPDATE_NOTIFICATIONS_ENABLED, enabled);
     }
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
@@ -25,6 +25,7 @@ public class VoxelSniperConfigLoader {
     protected static final String BRUSH_PROPERTIES = "brush-properties";
     private static final Logger LOGGER = LogManagerCompat.getLogger();
     private static final String CONFIG_VERSION = "config-version";
+    private static final String UPDATE_NOTIFICATIONS_ENABLED = "update-notifications";
     private static final String MESSAGE_ON_LOGIN_ENABLED = "message-on-login-enabled";
     private static final String PERSIST_SESSIONS_ON_LOGOUT = "persist-sessions-on-logout";
     private static final String DEFAULT_BLOCK_MATERIAL = "default-block-material";
@@ -35,7 +36,8 @@ public class VoxelSniperConfigLoader {
     private static final String BRUSH_SIZE_WARNING_THRESHOLD = "brush-size-warning-threshold";
     private static final String DEFAULT_VOXEL_HEIGHT = "default-voxel-height";
     private static final String DEFAULT_CYLINDER_CENTER = "default-cylinder-center";
-    private static final int CONFIG_VERSION_VALUE = 2;
+    private static final int CONFIG_VERSION_VALUE = 3;
+    private static final boolean DEFAULT_UPDATE_NOTIFICATIONS_ENABLED = true;
     private static final boolean DEFAULT_MESSAGE_ON_LOGIN_ENABLED = true;
     private static final boolean DEFAULT_PERSIST_SESSIONS_ON_LOGOUT = true;
     private static final BlockType DEFAULT_BLOCK_MATERIAL_VALUE = BlockTypes.AIR;
@@ -110,6 +112,9 @@ public class VoxelSniperConfigLoader {
             if (currentConfigVersion < 2) {
                 setPersistentSessions(arePersistentSessionsEnabled());
             }
+            if (currentConfigVersion < 3) {
+                setUpdateNotificationsEnabled(areUpdateNotificationsEnabled());
+            }
 
             plugin.saveConfig();
             LOGGER.info("Your config file is now up-to-date! (v{})", CONFIG_VERSION_VALUE);
@@ -133,6 +138,24 @@ public class VoxelSniperConfigLoader {
      */
     protected void setConfigVersion(int version) {
         this.config.set(CONFIG_VERSION, version);
+    }
+
+    /**
+     * Return if update notifications are enabled.
+     *
+     * @return {@code true} if notifications for updates are enabled, {@code false} otherwise.
+     */
+    public boolean areUpdateNotificationsEnabled() {
+        return this.config.getBoolean(UPDATE_NOTIFICATIONS_ENABLED, DEFAULT_UPDATE_NOTIFICATIONS_ENABLED);
+    }
+
+    /**
+     * Set the update notifier be enabled or disabled.
+     *
+     * @param enabled Update notifications enabled
+     */
+    protected void setUpdateNotificationsEnabled(boolean enabled) {
+        this.config.set(UPDATE_NOTIFICATIONS_ENABLED, enabled);
     }
 
     /**

--- a/src/main/java/com/thevoxelbox/voxelsniper/listener/PlayerJoinListener.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/listener/PlayerJoinListener.java
@@ -30,7 +30,7 @@ public class PlayerJoinListener implements Listener<PlayerJoinEvent> {
         Player player = event.getPlayer();
         UUID uuid = player.getUniqueId();
         Sniper sniper = getSniperFromRegistry(uuid);
-        if (player.hasPermission("voxelsniper.admin") && hasUpdate) {
+        if (player.hasPermission("voxelsniper.admin") && hasUpdate && config.areUpdateNotificationsEnabled()) {
             player.sendMessage(ChatColor.GOLD + "An update for FastAsyncVoxelSniper is available.");
             player.sendMessage(ChatColor.GOLD + "You are running version " +
                     ChatColor.AQUA + this.plugin.getDescription().getVersion() + ChatColor.GOLD + ", the latest version is " +

--- a/src/main/java/com/thevoxelbox/voxelsniper/listener/PlayerJoinListener.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/listener/PlayerJoinListener.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 
 import static com.thevoxelbox.voxelsniper.VoxelSniperPlugin.hasUpdate;
 import static com.thevoxelbox.voxelsniper.VoxelSniperPlugin.newVersionTitle;
+import static com.thevoxelbox.voxelsniper.VoxelSniperPlugin.updateCheckFailed;
 
 public class PlayerJoinListener implements Listener<PlayerJoinEvent> {
 
@@ -30,12 +31,16 @@ public class PlayerJoinListener implements Listener<PlayerJoinEvent> {
         Player player = event.getPlayer();
         UUID uuid = player.getUniqueId();
         Sniper sniper = getSniperFromRegistry(uuid);
-        if (player.hasPermission("voxelsniper.admin") && hasUpdate && config.areUpdateNotificationsEnabled()) {
-            player.sendMessage(ChatColor.GOLD + "An update for FastAsyncVoxelSniper is available.");
-            player.sendMessage(ChatColor.GOLD + "You are running version " +
-                    ChatColor.AQUA + this.plugin.getDescription().getVersion() + ChatColor.GOLD + ", the latest version is " +
-                    ChatColor.AQUA + newVersionTitle);
-            player.sendMessage(ChatColor.GOLD + "Update at https://dev.bukkit.org/projects/favs");
+        if (player.hasPermission("voxelsniper.admin") && (hasUpdate || updateCheckFailed) && config.areUpdateNotificationsEnabled()) {
+            if (updateCheckFailed) {
+                player.sendMessage(ChatColor.RED + "Could not check for FastAsyncVoxelSniper updates.");
+            } else {
+                player.sendMessage(ChatColor.GOLD + "An update for FastAsyncVoxelSniper is available.");
+                player.sendMessage(ChatColor.GOLD + "You are running version " +
+                        ChatColor.AQUA + this.plugin.getDescription().getVersion() + ChatColor.GOLD + ", the latest version is " +
+                        ChatColor.AQUA + newVersionTitle);
+                player.sendMessage(ChatColor.GOLD + "Update at https://dev.bukkit.org/projects/favs");
+            }
         }
         if (sniper == null) {
             return;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,6 @@
 # The config-version line is immutable. Don't change the value, it will reset itself after every reboot.
-config-version: 2
+config-version: 3
+update-notifications: true
 message-on-login-enabled: true
 persist-sessions-on-logout: true
 default-block-material: minecraft:air


### PR DESCRIPTION
## Overview
Fixes #97

## Description
I've gone ahead and added an option to disable the update notifications when a user joins the server.
Issue #97 mentions 

> wanting to reduce http calls

This has not been implemented (yet). I first wanted to collect feedback if this is something this configuration option should also affect? I have deliberately left it open for future addition of a /version command which could also notify about updates.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [ ] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.
