### PR TITLE
chore: Remove Fawe javadocs url

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,7 +87,6 @@ tasks {
         )
         opt.addBooleanOption("html5", true)
         opt.links("https://papermc.io/javadocs/paper/1.18/")
-        opt.links("https://ci.athion.net/job/FastAsyncWorldEdit-1.17-Core-Javadocs/javadoc/")
         opt.links("https://javadoc.io/doc/org.jetbrains/annotations/23.0.0/")
     }
 


### PR DESCRIPTION
Maybe we should type something