### PR TITLE
Fix ignored y height with splatter disc brush

### DIFF
--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterDiscBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterDiscBrush.java
@@ -159,6 +159,7 @@ public class SplatterDiscBrush extends AbstractPerformerBrush {
         }
         // Make the changes
         int blockX = targetBlock.getX();
+        int blockY = targetBlock.getY();
         int blockZ = targetBlock.getZ();
         double rSquared = Math.pow(brushSize + 1, 2);
         for (int x = 2 * brushSize; x >= 0; x--) {
@@ -167,10 +168,10 @@ public class SplatterDiscBrush extends AbstractPerformerBrush {
                 if (splat[x][y] == 1 && xSquared + Math.pow(y - brushSize - 1, 2) <= rSquared) {
                     this.performer.perform(
                             getEditSession(),
-                            blockX + x - brushSize,
-                            0,
-                            blockZ + y - brushSize,
-                            getBlock(blockX + x - brushSize, 0, blockZ + y - brushSize)
+                            blockX - brushSize + x,
+                            clampY(blockY),
+                            blockZ - brushSize + y,
+                            clampY(blockX - brushSize + x, blockY, blockZ - brushSize + y)
                     );
                 }
             }

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelCenterExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelCenterExecutor.java
@@ -38,8 +38,11 @@ public class VoxelCenterExecutor implements CommandExecutor {
         int center;
         try {
             center = Integer.parseInt(arguments[0]);
-        } catch (NumberFormatException | ArrayIndexOutOfBoundsException ignored) {
+        } catch (NumberFormatException ignored) {
             sender.sendMessage(ChatColor.RED + "Invalid input. Must be a number, not: " + arguments[0]);
+            return;
+        } catch (ArrayIndexOutOfBoundsException ignored) {
+            sender.sendMessage(ChatColor.RED + "Invalid input. Must be a number.");
             return;
         }
         toolkitProperties.setCylinderCenter(center);

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelHeightExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelHeightExecutor.java
@@ -38,8 +38,11 @@ public class VoxelHeightExecutor implements CommandExecutor {
         int height;
         try {
             height = Integer.parseInt(arguments[0]);
-        } catch (NumberFormatException | ArrayIndexOutOfBoundsException ignored) {
+        } catch (NumberFormatException ignored) {
             sender.sendMessage(ChatColor.RED + "Invalid input. Must be a number, not: " + arguments[0]);
+            return;
+        } catch (ArrayIndexOutOfBoundsException ignored) {
+            sender.sendMessage(ChatColor.RED + "Invalid input. Must be a number.");
             return;
         }
         toolkitProperties.setVoxelHeight(height);


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #139
Fixes #163

## Description
<!-- Please describe what this pull request does. -->

This pull request fixes a first issue ignoring y height of target block with ``Splatter`` Disc brush.
It also fixes a second former issue to property catch ``NFE`` and ``AIOOBE`` separately with ``/vh`` and ``/vc``.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
