### PR TITLE
Add configurable minY for FillDown brush

### DIFF
--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/FillDownBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/FillDownBrush.java
@@ -16,9 +16,11 @@ public class FillDownBrush extends AbstractPerformerBrush {
     private double trueCircle;
     private boolean fillLiquid = true;
     private boolean fromExisting;
+    private int minY;
 
     @Override
     public void loadProperties() {
+        this.minY = getEditSession().getMinY();
     }
 
     @Override
@@ -32,6 +34,7 @@ public class FillDownBrush extends AbstractPerformerBrush {
             messenger.sendMessage(ChatColor.AQUA + "/b fd all -- Fills into liquids as well. (Default)");
             messenger.sendMessage(ChatColor.AQUA + "/b fd some -- Fills only into air.");
             messenger.sendMessage(ChatColor.AQUA + "/b fd e -- Fills into only existing blocks. (Toggle)");
+            messenger.sendMessage(ChatColor.AQUA + "/b fd y [n] -- Sets the min y to n. (Must be >= than " + getEditSession().getMinY() + ")");
         } else {
             if (parameters.length == 1) {
                 if (firstParameter.equalsIgnoreCase("true")) {
@@ -110,7 +113,7 @@ public class FillDownBrush extends AbstractPerformerBrush {
                         }
                         y--;
                     }
-                    for (; y >= -(targetBlock.getY() - getEditSession().getMinY()); --y) {
+                    for (; y >= -(targetBlock.getY() - minY); --y) {
                         BlockType currentBlockType = getBlockType(
                                 targetBlock.getX() + x,
                                 targetBlock.getY() + y,
@@ -138,6 +141,7 @@ public class FillDownBrush extends AbstractPerformerBrush {
         snipe.createMessageSender()
                 .brushNameMessage()
                 .brushSizeMessage()
+                .message(ChatColor.GREEN + "Min y set to: " + this.minY)
                 .send();
     }
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/FillDownBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/FillDownBrush.java
@@ -6,6 +6,7 @@ import com.thevoxelbox.voxelsniper.sniper.snipe.Snipe;
 import com.thevoxelbox.voxelsniper.sniper.snipe.message.SnipeMessenger;
 import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import com.thevoxelbox.voxelsniper.util.material.Materials;
+import com.thevoxelbox.voxelsniper.util.text.NumericParser;
 import org.bukkit.ChatColor;
 
 import java.util.List;
@@ -58,6 +59,18 @@ public class FillDownBrush extends AbstractPerformerBrush {
                             : "all") + " blocks.");
                 } else {
                     messenger.sendMessage(ChatColor.RED + "Invalid brush parameters! Use the \"info\" parameter to display parameter info.");
+                }
+            } else if (parameters.length == 2) {
+                if (firstParameter.equalsIgnoreCase("y")) {
+                    Integer minY = NumericParser.parseInteger(parameters[1]);
+                    if (minY != null) {
+                        int minYMin = getEditSession().getMinY();
+                        int minYMax = getEditSession().getMaxY();
+                        this.minY = minY < minYMin ? minYMin : Math.min(minY, minYMax);
+                        messenger.sendMessage(ChatColor.AQUA + "Fill Down min y set to: " + this.minY);
+                    } else {
+                        messenger.sendMessage(ChatColor.RED + "Invalid number.");
+                    }
                 }
             } else {
                 messenger.sendMessage(ChatColor.RED + "Invalid brush parameters length! Use the \"info\" parameter to display " +
@@ -141,7 +154,7 @@ public class FillDownBrush extends AbstractPerformerBrush {
         snipe.createMessageSender()
                 .brushNameMessage()
                 .brushSizeMessage()
-                .message(ChatColor.GREEN + "Min y set to: " + this.minY)
+                .message(ChatColor.GREEN + "Fill Down min y set to: " + this.minY)
                 .send();
     }
 


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #176 

## Description
<!-- Please describe what this pull request does. -->
Adds a property for the min height. Default value is the min world y given by the ``EditSession``.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
