### PR TITLE
chore: Add crowdin workflow

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,39 @@
+name: Crowdin Action
+
+on:
+  schedule:
+    - cron: '0 */12 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: crowdin action
+        uses: crowdin/github-action@1.4.11
+        with:
+          upload_translations: false
+          download_translations: true
+          skip_untranslated_files: true
+          push_translations: true
+          export_only_approved: true
+          commit_message: 'feat: New Crowdin translations'
+          create_pull_request: true
+          pull_request_title: 'New Crowdin translations'
+          pull_request_labels: 'enhancement'
+          base_url: 'https://intellectualsites.crowdin.com'
+          config: 'crowdin.yml'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: 39
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FastAsyncVoxelSniper
 
+[![Crowdin](https://badges.crowdin.net/e/387f461acd0dfa902cb510bc3da3e0e3/localized.svg)](https://intellectualsites.crowdin.com/fastasyncvoxelsniper)
+
 This is a fork of [VoxelSniper](https://github.com/TVPT/VoxelSniper). It adds support for newer versions of [Spigot](https://www.spigotmc.org/) and [Paper](https://papermc.io/) keeping available all features from original version of plugin, but with some optimizations and code cleanup.
 
 ## Links
@@ -9,6 +11,7 @@ This is a fork of [VoxelSniper](https://github.com/TVPT/VoxelSniper). It adds su
 * [Issues](https://github.com/IntellectualSites/fastasyncvoxelsniper/issues)
 * [Wiki](https://intellectualsites.github.io/FastasyncVoxelSniper-Documentation/)
 * [JavaDocs](https://intellectualsites.github.io/fastasyncvoxelsniper-javadocs/)
+* [Translations](https://intellectualsites.crowdin.com/fastasyncvoxelsniper)
 
 ## Contributing
 See [here](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,8 @@
+files:
+  - source: '/src/main/resources/lang/strings.json'
+    ignore:
+      - '/src/main/resources/lang/%file_name%_%two_letters_code%.json'
+    translation: '/src/main/resources/lang/%file_name%_%two_letters_code%.json'
+
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN


### PR DESCRIPTION
I see you included the file in your previous PR @Aurelien30000, but Crowdin requires additional setup on https://intellectualsites.crowdin.com/.

The current proposal picks up strings.json as root translation file and exports translated files in the format `strings_de/fr/etc.` in the same folder again.