### PR TITLE
Add option to disable update checker and set update interval

### DIFF
--- a/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperPlugin.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperPlugin.java
@@ -40,6 +40,8 @@ import java.net.URLConnection;
 
 public class VoxelSniperPlugin extends JavaPlugin {
 
+    private static final long HOURS_TO_TICKS = 72000L;
+
     private static final Logger LOGGER = LogManagerCompat.getLogger();
     public static VoxelSniperPlugin plugin;
     public static String newVersionTitle = "";
@@ -83,6 +85,10 @@ public class VoxelSniperPlugin extends JavaPlugin {
         PaperLib.suggestPaper(this);
         currentVersionTitle = getDescription().getVersion().split("-")[0];
         currentVersion = Double.parseDouble(currentVersionTitle.replaceFirst("\\.", ""));
+        // Don't register task if update check is unwanted
+        if (!voxelSniperConfig.isUpdateCheckerEnabled()) {
+            return;
+        }
         this.getServer().getScheduler().runTaskTimerAsynchronously(this, () -> {
             try {
                 newVersion = updateCheck(currentVersion);
@@ -102,7 +108,7 @@ public class VoxelSniperPlugin extends JavaPlugin {
             } catch (Exception e) {
                 e.printStackTrace();
             }
-        }, 0L, 432000);
+        }, 0L, voxelSniperConfig.getUpdateCheckerInterval() * HOURS_TO_TICKS);
     }
 
     private VoxelSniperConfig loadConfig() {
@@ -111,7 +117,8 @@ public class VoxelSniperPlugin extends JavaPlugin {
         VoxelSniperConfigLoader voxelSniperConfigLoader = new VoxelSniperConfigLoader(this, config);
 
         return new VoxelSniperConfig(
-                voxelSniperConfigLoader.areUpdateNotificationsEnabled(),
+                voxelSniperConfigLoader.isUpdateCheckerEnabled(),
+                voxelSniperConfigLoader.getUpdateCheckerInterval(),
                 voxelSniperConfigLoader.isMessageOnLoginEnabled(),
                 voxelSniperConfigLoader.arePersistentSessionsEnabled(),
                 voxelSniperConfigLoader.getDefaultBlockMaterial(),

--- a/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfig.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfig.java
@@ -10,7 +10,8 @@ public class VoxelSniperConfig {
 
     private static final VoxelSniperPlugin plugin = VoxelSniperPlugin.plugin;
 
-    private final boolean updateNotificationsEnabled;
+    private final boolean updateCheckerEnabled;
+    private final int updateCheckerInterval;
     private final boolean messageOnLoginEnabled;
     private final boolean persistSessionsOnLogout;
     private final BlockType defaultBlockMaterial;
@@ -27,7 +28,8 @@ public class VoxelSniperConfig {
     /**
      * Create a new cached voxel configuration, used runtime.
      *
-     * @param updateNotificationsEnabled    notify whether updates are available or not
+     * @param updateCheckerEnabled          whether to check for updates
+     * @param updateCheckerInterval         period to wait in hours in-between checks
      * @param messageOnLoginEnabled         if message on login is enabled
      * @param persistSessionsOnLogout       if snipers shall be removed on logout
      * @param defaultBlockMaterial          default block material
@@ -41,7 +43,8 @@ public class VoxelSniperConfig {
      * @param brushProperties               brush properties
      */
     public VoxelSniperConfig(
-            boolean updateNotificationsEnabled,
+            boolean updateCheckerEnabled,
+            int updateCheckerInterval,
             boolean messageOnLoginEnabled,
             boolean persistSessionsOnLogout,
             BlockType defaultBlockMaterial,
@@ -54,7 +57,8 @@ public class VoxelSniperConfig {
             int defaultCylinderCenter,
             Map<String, Map<String, Object>> brushProperties
     ) {
-        this.updateNotificationsEnabled = updateNotificationsEnabled;
+        this.updateCheckerEnabled = updateCheckerEnabled;
+        this.updateCheckerInterval = updateCheckerInterval;
         this.messageOnLoginEnabled = messageOnLoginEnabled;
         this.persistSessionsOnLogout = persistSessionsOnLogout;
         this.defaultBlockMaterial = defaultBlockMaterial;
@@ -69,14 +73,25 @@ public class VoxelSniperConfig {
     }
 
     /**
-     * Return if update notifications are enabled.
+     * Return if update checker is enabled.
      *
-     * @return {@code true} if notifications for updates are enabled, {@code false} otherwise.
-     * @see VoxelSniperConfigLoader#areUpdateNotificationsEnabled()
-     * @since 2.3.0
+     * @return {@code true} if to check for updates periodically, {@code false} otherwise.
+     * @see VoxelSniperConfigLoader#isUpdateCheckerEnabled()
+     * @since TODO
      */
-    public boolean areUpdateNotificationsEnabled() {
-        return this.updateNotificationsEnabled;
+    public boolean isUpdateCheckerEnabled() {
+        return this.updateCheckerEnabled;
+    }
+
+    /**
+     * Return update interval in hours.
+     *
+     * @return interval in hours
+     * @see VoxelSniperConfigLoader#getUpdateCheckerInterval()
+     * @since TODO
+     */
+    public int getUpdateCheckerInterval() {
+        return this.updateCheckerInterval;
     }
 
     /**

--- a/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/config/VoxelSniperConfigLoader.java
@@ -25,7 +25,8 @@ public class VoxelSniperConfigLoader {
     protected static final String BRUSH_PROPERTIES = "brush-properties";
     private static final Logger LOGGER = LogManagerCompat.getLogger();
     private static final String CONFIG_VERSION = "config-version";
-    private static final String UPDATE_NOTIFICATIONS_ENABLED = "update-notifications";
+    private static final String UPDATE_CHECKER_ENABLED = "update-checker.enabled";
+    private static final String UPDATE_CHECKER_INTERVAL = "update-checker.interval";
     private static final String MESSAGE_ON_LOGIN_ENABLED = "message-on-login-enabled";
     private static final String PERSIST_SESSIONS_ON_LOGOUT = "persist-sessions-on-logout";
     private static final String DEFAULT_BLOCK_MATERIAL = "default-block-material";
@@ -36,8 +37,10 @@ public class VoxelSniperConfigLoader {
     private static final String BRUSH_SIZE_WARNING_THRESHOLD = "brush-size-warning-threshold";
     private static final String DEFAULT_VOXEL_HEIGHT = "default-voxel-height";
     private static final String DEFAULT_CYLINDER_CENTER = "default-cylinder-center";
-    private static final int CONFIG_VERSION_VALUE = 5;
-    private static final boolean DEFAULT_UPDATE_NOTIFICATIONS_ENABLED = true;
+    private static final int CONFIG_VERSION_VALUE = 6;
+    private static final boolean DEFAULT_UPDATE_CHECKER_ENABLED = true;
+    private static final int MIN_UPDATE_CHECKER_INTERVAL = 6;
+    private static final int DEFAULT_UPDATE_CHECKER_INTERVAL = 6;
     private static final boolean DEFAULT_MESSAGE_ON_LOGIN_ENABLED = true;
     private static final boolean DEFAULT_PERSIST_SESSIONS_ON_LOGOUT = true;
     private static final BlockType DEFAULT_BLOCK_MATERIAL_VALUE = BlockTypes.AIR;
@@ -115,9 +118,6 @@ public class VoxelSniperConfigLoader {
             if (currentConfigVersion < 2) {
                 setPersistentSessions(arePersistentSessionsEnabled());
             }
-            if (currentConfigVersion < 3) {
-                enableUpdateNotifications(areUpdateNotificationsEnabled());
-            }
             if (currentConfigVersion < 4) {
                 Map<String, Map<String, Object>> brushProperties = getBrushProperties();
                 Map<String, Object> jaggedLineBrush = brushProperties.get("Jagged Line");
@@ -139,6 +139,10 @@ public class VoxelSniperConfigLoader {
             if (currentConfigVersion < 5) {
                 setBrushProperty("Stencil", "default-max-area-volume", 5000000);
                 setBrushProperty("Stencil", "default-max-save-volume", 50000);
+            }
+            if (currentConfigVersion < 6) {
+                enableUpdateChecker(isUpdateCheckerEnabled());
+                setUpdateCheckerInterval(getUpdateCheckerInterval());
             }
 
             plugin.saveConfig();
@@ -165,23 +169,43 @@ public class VoxelSniperConfigLoader {
     }
 
     /**
-     * Return if update notifications are enabled.
+     * Return if update checker is enabled.
      *
-     * @return {@code true} if notifications for updates are enabled, {@code false} otherwise.
-     * @since 2.3.0
+     * @return {@code true} if to check for updates periodically, {@code false} otherwise.
+     * @since TODO
      */
-    public boolean areUpdateNotificationsEnabled() {
-        return this.config.getBoolean(UPDATE_NOTIFICATIONS_ENABLED, DEFAULT_UPDATE_NOTIFICATIONS_ENABLED);
+    public boolean isUpdateCheckerEnabled() {
+        return this.config.getBoolean(UPDATE_CHECKER_ENABLED, DEFAULT_UPDATE_CHECKER_ENABLED);
     }
 
     /**
-     * Set the update notifier be enabled or disabled.
+     * Set the update checker be enabled or disabled.
      *
-     * @param enabled Update notifications enabled
-     * @since 2.3.0
+     * @param enabled Update checker enabled
+     * @since TODO
      */
-    protected void enableUpdateNotifications(boolean enabled) {
-        this.config.set(UPDATE_NOTIFICATIONS_ENABLED, enabled);
+    public void enableUpdateChecker(boolean enabled) {
+        this.config.set(UPDATE_CHECKER_ENABLED, enabled);
+    }
+
+    /**
+     * Return update interval in hours.
+     *
+     * @return interval in hours
+     * @since TODO
+     */
+    public int getUpdateCheckerInterval() {
+        return Math.max(MIN_UPDATE_CHECKER_INTERVAL, this.config.getInt(UPDATE_CHECKER_INTERVAL, DEFAULT_UPDATE_CHECKER_INTERVAL));
+    }
+
+    /**
+     * Set the update checker waiting interval.
+     *
+     * @param interval Period to wait in hours in-between checks
+     * @since TODO
+     */
+    public void setUpdateCheckerInterval(int interval) {
+        this.config.set(UPDATE_CHECKER_INTERVAL, interval);
     }
 
     /**

--- a/src/main/java/com/thevoxelbox/voxelsniper/listener/PlayerJoinListener.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/listener/PlayerJoinListener.java
@@ -29,7 +29,7 @@ public class PlayerJoinListener implements Listener<PlayerJoinEvent> {
         VoxelSniperConfig config = this.plugin.getVoxelSniperConfig();
         Player player = event.getPlayer();
         Sniper sniper = getSniperFromRegistry(player);
-        if (player.hasPermission("voxelsniper.admin") && (hasUpdate || updateCheckFailed) && config.areUpdateNotificationsEnabled()) {
+        if (player.hasPermission("voxelsniper.admin") && (hasUpdate || updateCheckFailed)) {
             if (updateCheckFailed) {
                 sniper.print(Caption.of("favs.info.update.check-failed"));
             } else {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,8 @@
 # The config-version line is immutable. Don't change the value, it will reset itself after every reboot.
-config-version: 5
-update-notifications: true
+config-version: 6
+update-checker:
+  enabled: true
+  interval: 6
 message-on-login-enabled: true
 persist-sessions-on-logout: true
 default-block-material: minecraft:air


### PR DESCRIPTION
## Overview
Adds:
- option to enable/disable update checker
- option to specify update interval 

Fixes #150

## Description
I've gone ahead and added an option to disable the update checker all-together.
The update interval can now be specified in the configuration file. 
I'm unsure how to best communicate to the end-user that the value has a time unit of hours, as the config doesn't come with comments. Perhaps this info could be added to a wiki page?
I have also grouped the update checker settings together and added a config migration.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
