### PR TITLE
Pin GH actions to SHA to avoid mutable refs

### DIFF
--- a/.github/workflows/announce-release-on-discord.yml
+++ b/.github/workflows/announce-release-on-discord.yml
@@ -2,7 +2,6 @@ name: Announce release on discord
 on:
   release:
     types: [published]
-
 jobs:
   send_announcement:
     runs-on: ubuntu-latest
@@ -12,7 +11,7 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           DISCORD_USERNAME: FastAsyncVoxelSniper Release
           DISCORD_AVATAR: https://cdn-raw.modrinth.com//data/D7XBSI1y/icon.png
-        uses: Ilshidur/action-discord@0.3.2
+        uses: Ilshidur/action-discord@0c4b27844ba47cb1c7bee539c8eead5284ce9fa9 # ratchet:Ilshidur/action-discord@0.3.2
         with:
           args: |
             "<@&673137848211472384>"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,5 @@
 name: build
-
 on: [pull_request, push]
-
 jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
@@ -9,8 +7,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
-      - name : Validate Gradle Wrapper
-        uses : gradle/wrapper-validation-action@v1
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6 # v1
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -18,11 +16,11 @@ jobs:
           java-version: 17
       - name: Clean Build
         run: ./gradlew clean build --no-daemon
-      - name : Archive Artifacts
-        uses : actions/upload-artifact@v3
-        with :
-          name : FastAsyncVoxelSniper-SNAPSHOT
-          path : build/libs/*-SNAPSHOT.jar
+      - name: Archive Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: FastAsyncVoxelSniper-SNAPSHOT
+          path: build/libs/*-SNAPSHOT.jar
       - name: Determine release status
         if: ${{ runner.os == 'Linux' }}
         run: |
@@ -34,20 +32,20 @@ jobs:
       - name: Publish Release
         if: ${{ runner.os == 'Linux' && env.STATUS == 'release' && github.event_name == 'push' && github.ref == 'refs/heads/main'}}
         run: ./gradlew publishToSonatype closeSonatypeStagingRepository --info
-        env :
-          ORG_GRADLE_PROJECT_sonatypeUsername : ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword : ${{ secrets.SONATYPE_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingKey : ${{ secrets.SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword : ${{ secrets.SIGNING_PASSWORD }}
-      - name : Publish Snapshot
-        if : ${{ runner.os == 'Linux' && env.STATUS != 'release' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        run : ./gradlew publishToSonatype
-        env :
-          ORG_GRADLE_PROJECT_sonatypeUsername : ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword : ${{ secrets.SONATYPE_PASSWORD }}
+        env:
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+      - name: Publish Snapshot
+        if: ${{ runner.os == 'Linux' && env.STATUS != 'release' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: ./gradlew publishToSonatype
+        env:
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
       - name: Publish javadocs
         if: ${{ runner.os == 'Linux' && env.STATUS == 'release' && github.event_name == 'push' && github.ref == 'refs/heads/main'}}
-        uses: cpina/github-action-push-to-another-repository@main
+        uses: cpina/github-action-push-to-another-repository@0a14457bb28b04dfa1652e0ffdfda866d2845c73 # main
         env:
           SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
         with:
@@ -60,17 +58,17 @@ jobs:
         if: ${{ runner.os == 'Linux' && env.STATUS == 'release' && github.event_name == 'push' && github.ref == 'refs/heads/main'}}
         run: ./gradlew modrinth
         env:
-          MODRINTH_TOKEN : ${{ secrets.MODRINTH_TOKEN }}
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
       - name: Publish to GitHub actions
         if: ${{ runner.os == 'Linux' && env.STATUS == 'release' && github.event_name == 'push' && github.ref == 'refs/heads/main'}}
-        uses: AButler/upload-release-assets@v2.0
+        uses: AButler/upload-release-assets@ec6d3263266dc57eb6645b5f75e827987f7c217d # ratchet:AButler/upload-release-assets@v2.0
         with:
           files: build/libs/fastasyncvoxelsniper-${{ github.event.release.tag_name }}.jar
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           release-tag: ${{ github.event.release.tag_name }}
-      - name : Publish to CurseForge
-        if : ${{ runner.os == 'Linux' && env.STATUS == 'release' && github.event_name == 'push' && github.ref == 'refs/heads/main'}}
-        uses: itsmeow/curseforge-upload@v3
+      - name: Publish to CurseForge
+        if: ${{ runner.os == 'Linux' && env.STATUS == 'release' && github.event_name == 'push' && github.ref == 'refs/heads/main'}}
+        uses: itsmeow/curseforge-upload@13f278adc4cc7b881555f87e6ea528387dd6492b # v3
         with:
           file_path: build/libs/fastasyncvoxelsniper-${{ env.VERSION }}.jar
           # https://minecraft.curseforge.com/api/game/versions?token=redacted

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,10 @@
 name: "CodeQL"
-
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
-
+    branches: [main]
 jobs:
   analyze:
     name: Analyze
@@ -15,23 +13,18 @@ jobs:
       actions: read
       contents: read
       security-events: write
-
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'java' ]
-
+        language: ['java']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@32dc499307d133bb5085bae78498c0ac2cf762d5 # v2
         with:
           languages: ${{ matrix.language }}
-
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
-
+        uses: github/codeql-action/autobuild@32dc499307d133bb5085bae78498c0ac2cf762d5 # v2
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@32dc499307d133bb5085bae78498c0ac2cf762d5 # v2

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,26 +1,20 @@
 name: Crowdin Action
-
 on:
   schedule:
     - cron: '0 */12 * * *'
   workflow_dispatch:
-
 permissions:
   actions: write
   contents: write
   pull-requests: write
-
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest
-
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
-
       - name: crowdin action
-        uses: crowdin/github-action@v1.7.0
+        uses: crowdin/github-action@37e7ee2f55c30ccc6d6064db2276c1c4294c9ad5 # v1.7.0
         with:
           upload_translations: false
           download_translations: true

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,14 +1,12 @@
 name: draft release
-
 on:
   push:
     branches:
       - main
   pull_request:
-    types: [ opened, reopened, synchronize ]
+    types: [opened, reopened, synchronize]
   pull_request_target:
-    types: [ opened, reopened, synchronize ]
-
+    types: [opened, reopened, synchronize]
 jobs:
   update_release_draft:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
GitHub actions are mutable if not pinned, which allow modifications without revision changes. Let's pin external versions to ensure the version specified matches the version GH action pulls.