### PR TITLE
Improve generate tree brush with persistent leaves

### DIFF
--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/GenerateTreeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/GenerateTreeBrush.java
@@ -1,6 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
 import com.fastasyncworldedit.core.configuration.Caption;
+import com.fastasyncworldedit.core.registry.state.PropertyKey;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockCategories;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -397,7 +398,9 @@ public class GenerateTreeBrush extends AbstractBrush {
             BlockState block = getBlock(x, y, z);
             if (block.isAir()) {
                 // Creates block.
-                setBlock(x, clampY(y), z, this.leafType);
+                setBlockData(x, clampY(y), z, this.leafType
+                        .getDefaultState()
+                        .with(PropertyKey.PERSISTENT, true));
             }
         }
     }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #290 

## Description
<!-- Please describe what this pull request does. -->
Use FAWE block state & block data to set the ``persistent`` property of leaves to ``true``, so they don't decay unexpectedly.


```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
