### PR TITLE
Update modrinth's list of supported versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,12 +27,8 @@ body:
       description: Which server version version you using? If your server version is not listed, it is not supported. Update to a supported version first.
       multiple: false
       options:
-        - '1.20'
+        - '1.20.1'
         - '1.19.4'
-        - '1.19.3'
-        - '1.19.2'
-        - '1.19.1'
-        - '1.19'
         - '1.18.2'
         - '1.17.1'
         - '1.16.5'

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,11 +27,10 @@ body:
       description: Which server version version you using? If your server version is not listed, it is not supported. Update to a supported version first.
       multiple: false
       options:
-        - '1.20.1'
+        - '1.20.2'
         - '1.19.4'
         - '1.18.2'
         - '1.17.1'
-        - '1.16.5'
     validations:
       required: true
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -186,7 +186,8 @@ nexusPublishing {
     }
 }
 
-val supportedVersions = listOf("1.16.5", "1.17.1", "1.18.2", "1.19", "1.19.1", "1.19.2", "1.19.3", "1.19.4", "1.20", "1.20.1")
+// Keep in sync with FAWE versions
+val supportedVersions = listOf("1.16.5", "1.17.1", "1.18.2", "1.19.4", "1.20", "1.20.1")
 
 modrinth {
     token.set(System.getenv("MODRINTH_TOKEN"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -187,7 +187,7 @@ nexusPublishing {
 }
 
 // Keep in sync with FAWE versions
-val supportedVersions = listOf("1.16.5", "1.17.1", "1.18.2", "1.19.4", "1.20", "1.20.1")
+val supportedVersions = listOf("1.17.1", "1.18.2", "1.19.4", "1.20", "1.20.1")
 
 modrinth {
     token.set(System.getenv("MODRINTH_TOKEN"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -187,7 +187,7 @@ nexusPublishing {
 }
 
 // Keep in sync with FAWE versions
-val supportedVersions = listOf("1.17.1", "1.18.2", "1.19.4", "1.20", "1.20.1")
+val supportedVersions = listOf("1.17.1", "1.18.2", "1.19.4", "1.20", "1.20.1", "1.20.2")
 
 modrinth {
     token.set(System.getenv("MODRINTH_TOKEN"))


### PR DESCRIPTION
FAWE supports 1.19.4 only, and given FAVS depends on FAWE, this list must be kept in sync.