### PR TITLE
feature: update to cloud v2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,12 @@ java {
 
 repositories {
     mavenCentral()
+    maven("https://oss.sonatype.org/content/repositories/snapshots/") {
+        name = "sonatypeOssSnapshots"
+        mavenContent {
+            snapshotsOnly()
+        }
+    }
     maven { url = uri("https://repo.papermc.io/repository/maven-public/") }
 }
 
@@ -82,6 +88,7 @@ tasks {
     compileJava {
         options.compilerArgs.addAll(arrayOf("-Xmaxerrs", "1000"))
         options.compilerArgs.add("-Xlint:all")
+        options.compilerArgs.add("-parameters")
         for (disabledLint in arrayOf("processing", "path", "fallthrough", "serial"))
             options.compilerArgs.add("-Xlint:$disabledLint")
         options.isDeprecation = true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,8 @@
 annotations = "24.1.0"
 
 # Cloud command system
-cloud = "1.8.4"
+cloud = "2.0.0-beta.1"
+cloudMinecraft = "2.0.0-SNAPSHOT"
 
 # Gradle plugins
 shadow = "8.1.1"
@@ -19,10 +20,10 @@ runPaper = "2.2.2"
 annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }
 
 # Cloud command system
-cloudcore = { group = "cloud.commandframework", name = "cloud-core", version.ref = "cloud" }
-cloudannotations = { group = "cloud.commandframework", name = "cloud-annotations", version.ref = "cloud" }
-cloudbukkit = { group = "cloud.commandframework", name = "cloud-bukkit", version.ref = "cloud" }
-cloudpaper = { group = "cloud.commandframework", name = "cloud-paper", version.ref = "cloud" }
+cloudcore = { group = "org.incendo", name = "cloud-core", version.ref = "cloud" }
+cloudannotations = { group = "org.incendo", name = "cloud-annotations", version.ref = "cloudMinecraft" }
+cloudbukkit = { group = "org.incendo", name = "cloud-bukkit", version.ref = "cloudMinecraft" }
+cloudpaper = { group = "org.incendo", name = "cloud-paper", version.ref = "cloudMinecraft" }
 
 [plugins]
 shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BiomeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BiomeBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -18,8 +18,8 @@ import com.thevoxelbox.voxelsniper.util.minecraft.Identifiers;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b biome|bio")
-@CommandPermission("voxelsniper.brush.biome")
+@Command(value = "brush|b biome|bio")
+@Permission("voxelsniper.brush.biome")
 public class BiomeBrush extends AbstractBrush {
 
     private static final BiomeType DEFAULT_BIOME_TYPE = BiomeTypes.PLAINS;
@@ -31,21 +31,21 @@ public class BiomeBrush extends AbstractBrush {
         this.biomeType = (BiomeType) getRegistryProperty("default-biome-type", BiomeType.REGISTRY, DEFAULT_BIOME_TYPE);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.biome.info"));
     }
 
-    @CommandMethod("list")
+    @Command("list")
     public void onBrushList(
             final @NotNull Snipe snipe
     ) {
@@ -60,7 +60,7 @@ public class BiomeBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("<biome-type>")
+    @Command("<biome-type>")
     public void onBrushBiometype(
             final @NotNull Snipe snipe,
             final @NotNull @Argument("biome-type") BiomeType biomeType

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BlockResetBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BlockResetBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockCategories;
 import com.sk89q.worldedit.world.block.BlockType;
@@ -14,8 +14,8 @@ import com.thevoxelbox.voxelsniper.util.material.MaterialSets;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b block_reset|blockreset|br")
-@CommandPermission("voxelsniper.brush.blockreset")
+@Command(value = "brush|b block_reset|blockreset|br")
+@Permission("voxelsniper.brush.blockreset")
 public class BlockResetBrush extends AbstractBrush {
 
     private static final MaterialSet DENIED_UPDATES = MaterialSet.builder()
@@ -32,7 +32,7 @@ public class BlockResetBrush extends AbstractBrush {
             .add(BlockTypes.COMPARATOR)
             .build();
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BlockResetSurfaceBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/BlockResetSurfaceBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockCategories;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -27,8 +27,8 @@ import org.jetbrains.annotations.NotNull;
  * brushes.
  */
 @RequireToolkit
-@CommandMethod(value = "brush|b block_reset_surface|blockresetsurface|brs")
-@CommandPermission("voxelsniper.brush.blockresetsurface")
+@Command(value = "brush|b block_reset_surface|blockresetsurface|brs")
+@Permission("voxelsniper.brush.blockresetsurface")
 public class BlockResetSurfaceBrush extends AbstractBrush {
 
     private static final MaterialSet DENIED_UPDATES = MaterialSet.builder()
@@ -46,7 +46,7 @@ public class BlockResetSurfaceBrush extends AbstractBrush {
             .add(BlockTypes.COMPARATOR)
             .build();
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/CleanSnowBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/CleanSnowBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Liberal;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Liberal;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockTypes;
@@ -16,27 +16,27 @@ import com.thevoxelbox.voxelsniper.util.message.VoxelSniperText;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b clean_snow|cleansnow|cls")
-@CommandPermission("voxelsniper.brush.cleansnow")
+@Command(value = "brush|b clean_snow|cleansnow|cls")
+@Permission("voxelsniper.brush.cleansnow")
 public class CleanSnowBrush extends AbstractBrush {
 
     private boolean trueCircle;
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.clean-snow.info"));
     }
 
-    @CommandMethod("<true-circle>")
+    @Command("<true-circle>")
     public void onBrushTruecircle(
             final @NotNull Snipe snipe,
             final @Argument("true-circle") @Liberal boolean trueCircle

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/CometBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/CometBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Liberal;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Liberal;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -20,27 +20,27 @@ import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b comet|meteor|com|met")
-@CommandPermission("voxelsniper.brush.comet")
+@Command(value = "brush|b comet|meteor|com|met")
+@Permission("voxelsniper.brush.comet")
 public class CometBrush extends AbstractBrush {
 
     private boolean useBigBalls;
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.comet.info"));
     }
 
-    @CommandMethod("<use-big-balls>")
+    @Command("<use-big-balls>")
     public void onBrushBigballs(
             final @NotNull Snipe snipe,
             final @Argument("use-big-balls") @Liberal boolean useBigBalls
@@ -54,14 +54,14 @@ public class CometBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("balls big")
+    @Command("balls big")
     public void onBrushBallsBig(
             final @NotNull Snipe snipe
     ) {
         this.onBrushBigballs(snipe, true);
     }
 
-    @CommandMethod("balls small")
+    @Command("balls small")
     public void onBrushBallsSmall(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/CopyPastaBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/CopyPastaBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -14,8 +14,8 @@ import com.thevoxelbox.voxelsniper.util.message.VoxelSniperText;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b copy_pasta|copypasta|cp")
-@CommandPermission("voxelsniper.brush.copypasta")
+@Command(value = "brush|b copy_pasta|copypasta|cp")
+@Permission("voxelsniper.brush.copypasta")
 public class CopyPastaBrush extends AbstractBrush {
 
     private static final int BLOCK_LIMIT = 10000;
@@ -38,21 +38,21 @@ public class CopyPastaBrush extends AbstractBrush {
         this.blockLimit = getIntegerProperty("block-limit", BLOCK_LIMIT);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.copy-pasta.info"));
     }
 
-    @CommandMethod("air")
+    @Command("air")
     public void onBrushAir(
             final @NotNull Snipe snipe
     ) {
@@ -75,28 +75,28 @@ public class CopyPastaBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("0")
+    @Command("0")
     public void onBrush0(
             final @NotNull Snipe snipe
     ) {
         this.onBrushPivotCommand(snipe, 0);
     }
 
-    @CommandMethod("90")
+    @Command("90")
     public void onBrush90(
             final @NotNull Snipe snipe
     ) {
         this.onBrushPivotCommand(snipe, 90);
     }
 
-    @CommandMethod("180")
+    @Command("180")
     public void onBrush180(
             final @NotNull Snipe snipe
     ) {
         this.onBrushPivotCommand(snipe, 180);
     }
 
-    @CommandMethod("270")
+    @Command("270")
     public void onBrush270(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/DomeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/DomeBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -17,11 +17,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b dome|do")
-@CommandPermission("voxelsniper.brush.dome")
+@Command(value = "brush|b dome|do")
+@Permission("voxelsniper.brush.dome")
 public class DomeBrush extends AbstractBrush {
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/DrainBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/DrainBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Liberal;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Liberal;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockType;
@@ -18,28 +18,28 @@ import com.thevoxelbox.voxelsniper.util.message.VoxelSniperText;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b drain|dr")
-@CommandPermission("voxelsniper.brush.drain")
+@Command(value = "brush|b drain|dr")
+@Permission("voxelsniper.brush.drain")
 public class DrainBrush extends AbstractBrush {
 
     private boolean trueCircle;
     private boolean disc;
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.drain.info"));
     }
 
-    @CommandMethod("<true-circle>")
+    @Command("<true-circle>")
     public void onBrushTruecircle(
             final @NotNull Snipe snipe,
             final @Argument("true-circle") @Liberal boolean trueCircle
@@ -53,7 +53,7 @@ public class DrainBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("d")
+    @Command("d")
     public void onBrushD(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/EraserBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/EraserBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockCategories;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -14,8 +14,8 @@ import com.thevoxelbox.voxelsniper.util.material.MaterialSets;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b eraser|erase")
-@CommandPermission("voxelsniper.brush.eraser")
+@Command(value = "brush|b eraser|erase")
+@Permission("voxelsniper.brush.eraser")
 public class EraserBrush extends AbstractBrush {
 
     private static final MaterialSet EXCLUSIVE_MATERIALS = MaterialSet.builder()
@@ -33,7 +33,7 @@ public class EraserBrush extends AbstractBrush {
             .with(MaterialSets.LIQUIDS)
             .build();
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ErodeBlendBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ErodeBlendBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Range;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Range;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.thevoxelbox.voxelsniper.brush.type.blend.BlendBallBrush;
@@ -13,8 +13,8 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolAction;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b erode_blend|erode_blend_ball|erodeblend|erodeblendball|eb")
-@CommandPermission("voxelsniper.brush.erodeblend")
+@Command(value = "brush|b erode_blend|erode_blend_ball|erodeblend|erodeblendball|eb")
+@Permission("voxelsniper.brush.erodeblend")
 public class ErodeBlendBrush extends AbstractBrush {
 
     private final BlendBallBrush blendBall;
@@ -25,7 +25,7 @@ public class ErodeBlendBrush extends AbstractBrush {
         this.erode = new ErodeBrush();
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
@@ -33,7 +33,7 @@ public class ErodeBlendBrush extends AbstractBrush {
         this.erode.onBrush(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
@@ -41,14 +41,14 @@ public class ErodeBlendBrush extends AbstractBrush {
         this.erode.onBrushInfo(snipe);
     }
 
-    @CommandMethod("water")
+    @Command("water")
     public void onBrushWater(
             final @NotNull Snipe snipe
     ) {
         this.blendBall.onBrushWater(snipe);
     }
 
-    @CommandMethod("<preset>")
+    @Command("<preset>")
     public void onBrushPreset(
             final @NotNull Snipe snipe,
 
@@ -57,7 +57,7 @@ public class ErodeBlendBrush extends AbstractBrush {
         this.erode.onBrushPreset(snipe, preset);
     }
 
-    @CommandMethod("e <erosion-faces>")
+    @Command("e <erosion-faces>")
     public void onBrushErosionfaces(
             final @NotNull Snipe snipe,
             final @Argument("erosion-faces") @Range(min = "0") int erosionFaces
@@ -65,7 +65,7 @@ public class ErodeBlendBrush extends AbstractBrush {
         this.erode.onBrushErosionfaces(snipe, erosionFaces);
     }
 
-    @CommandMethod("E <erosion-recursions>")
+    @Command("E <erosion-recursions>")
     public void onBrushErosionrecursion(
             final @NotNull Snipe snipe,
             final @Argument("erosion-recursions") @Range(min = "0") int erosionRecursions
@@ -73,7 +73,7 @@ public class ErodeBlendBrush extends AbstractBrush {
         this.erode.onBrushErosionrecursion(snipe, erosionRecursions);
     }
 
-    @CommandMethod("f <fill-faces>")
+    @Command("f <fill-faces>")
     public void onBrushFillfaces(
             final @NotNull Snipe snipe,
             final @Argument("fill-faces") @Range(min = "0") int fillFaces
@@ -81,7 +81,7 @@ public class ErodeBlendBrush extends AbstractBrush {
         this.erode.onBrushFillfaces(snipe, fillFaces);
     }
 
-    @CommandMethod("F <fill-recursions>")
+    @Command("F <fill-recursions>")
     public void onBrushFillrecursion(
             final @NotNull Snipe snipe,
             final @Argument("fill-recursions") @Range(min = "0") int fillRecursions

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ErodeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ErodeBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Range;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Range;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -32,8 +32,8 @@ import java.util.Map;
 import java.util.Objects;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b erode|e")
-@CommandPermission("voxelsniper.brush.erode")
+@Command(value = "brush|b erode|e")
+@Permission("voxelsniper.brush.erode")
 public class ErodeBrush extends AbstractBrush {
 
     private static final List<Direction> FACES_TO_CHECK = Arrays.asList(
@@ -47,21 +47,21 @@ public class ErodeBrush extends AbstractBrush {
 
     private ErosionPreset currentPreset = Preset.DEFAULT.getPreset();
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.erode.info"));
     }
 
-    @CommandMethod("<preset>")
+    @Command("<preset>")
     public void onBrushPreset(
             final @NotNull Snipe snipe,
             final @NotNull @Argument("preset") Preset preset
@@ -75,7 +75,7 @@ public class ErodeBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("e <erosion-faces>")
+    @Command("e <erosion-faces>")
     public void onBrushErosionfaces(
             final @NotNull Snipe snipe,
             final @Argument("erosion-faces") @Range(min = "0") int erosionFaces
@@ -94,7 +94,7 @@ public class ErodeBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("E <erosion-recursions>")
+    @Command("E <erosion-recursions>")
     public void onBrushErosionrecursion(
             final @NotNull Snipe snipe,
             final @Argument("erosion-recursions") @Range(min = "0") int erosionRecursions
@@ -113,7 +113,7 @@ public class ErodeBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("f <fill-faces>")
+    @Command("f <fill-faces>")
     public void onBrushFillfaces(
             final @NotNull Snipe snipe,
             final @Argument("fill-faces") @Range(min = "0") int fillFaces
@@ -132,7 +132,7 @@ public class ErodeBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("F <fill-recursions>")
+    @Command("F <fill-recursions>")
     public void onBrushFillrecursion(
             final @NotNull Snipe snipe,
             final @Argument("fill-recursions") @Range(min = "0") int fillRecursions

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ExtrudeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ExtrudeBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Liberal;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Liberal;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Direction;
@@ -17,27 +17,27 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b extrude|ex")
-@CommandPermission("voxelsniper.brush.extrude")
+@Command(value = "brush|b extrude|ex")
+@Permission("voxelsniper.brush.extrude")
 public class ExtrudeBrush extends AbstractBrush {
 
     private boolean trueCircle;
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.extrude.info"));
     }
 
-    @CommandMethod("<true-circle>")
+    @Command("<true-circle>")
     public void onBrushTruecircle(
             final @NotNull Snipe snipe,
             final @Argument("true-circle") @Liberal boolean trueCircle

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/FlatOceanBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/FlatOceanBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -13,8 +13,8 @@ import com.thevoxelbox.voxelsniper.sniper.snipe.message.SnipeMessenger;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b flat_ocean|flatocean|fo")
-@CommandPermission("voxelsniper.brush.flatocean")
+@Command(value = "brush|b flat_ocean|flatocean|fo")
+@Permission("voxelsniper.brush.flatocean")
 public class FlatOceanBrush extends AbstractBrush {
 
     private static final int DEFAULT_WATER_LEVEL = 29;
@@ -29,21 +29,21 @@ public class FlatOceanBrush extends AbstractBrush {
         this.floorLevel = getIntegerProperty("default-floor-level", DEFAULT_FLOOR_LEVEL);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.flat-ocean.info"));
     }
 
-    @CommandMethod("yo <water-level>")
+    @Command("yo <water-level>")
     public void onBrushYo(
             final @NotNull Snipe snipe,
             final @Argument("water-level") int waterLevel
@@ -57,7 +57,7 @@ public class FlatOceanBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("yl <floor-level>")
+    @Command("yl <floor-level>")
     public void onBrushYl(
             final @NotNull Snipe snipe,
             final @Argument("floor-level") int floorLevel

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/GenerateTreeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/GenerateTreeBrush.java
@@ -1,10 +1,10 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Liberal;
-import cloud.commandframework.annotations.specifier.Range;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Liberal;
+import org.incendo.cloud.annotation.specifier.Range;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.fastasyncworldedit.core.registry.state.PropertyKey;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -27,8 +27,8 @@ import java.util.Random;
 
 // Proposal: Use /v and /vr for leave and wood material // or two more parameters -- Monofraps
 @RequireToolkit
-@CommandMethod(value = "brush|b generate_tree|generatetree|gt")
-@CommandPermission("voxelsniper.brush.generatetree")
+@Command(value = "brush|b generate_tree|generatetree|gt")
+@Permission("voxelsniper.brush.generatetree")
 public class GenerateTreeBrush extends AbstractBrush {
 
     private static final BlockType DEFAULT_LEAF_TYPE = BlockTypes.OAK_LEAVES;
@@ -98,21 +98,21 @@ public class GenerateTreeBrush extends AbstractBrush {
         this.nodeMax = getIntegerProperty("default-node-max", DEFAULT_NODE_MAX);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.generate-tree.info"));
     }
 
-    @CommandMethod("default")
+    @Command("default")
     public void onBrushDefault(
             final @NotNull Snipe snipe
     ) {
@@ -122,7 +122,7 @@ public class GenerateTreeBrush extends AbstractBrush {
         messenger.sendMessage(Caption.of("voxelsniper.brush.parameter.reset"));
     }
 
-    @CommandMethod("lt <leaf-type>")
+    @Command("lt <leaf-type>")
     public void onBrushLt(
             final @NotNull Snipe snipe,
             final @NotNull @Argument("leaf-type") BlockType leafType
@@ -136,7 +136,7 @@ public class GenerateTreeBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("wt <wood-type>")
+    @Command("wt <wood-type>")
     public void onBrushWt(
             final @NotNull Snipe snipe,
             final @NotNull @Argument("wood-type") BlockType woodType
@@ -150,7 +150,7 @@ public class GenerateTreeBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("tt <thickness>")
+    @Command("tt <thickness>")
     public void onBrushTt(
             final @NotNull Snipe snipe,
             final @Argument("thickness") @Range(min = "0") int thickness
@@ -164,7 +164,7 @@ public class GenerateTreeBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("rf <root-float>")
+    @Command("rf <root-float>")
     public void onBrushRf(
             final @NotNull Snipe snipe,
             final @Argument("root-float") @Liberal boolean rootFloat
@@ -178,7 +178,7 @@ public class GenerateTreeBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("sh <start-height>")
+    @Command("sh <start-height>")
     public void onBrushSh(
             final @NotNull Snipe snipe,
             final @Argument("start-height") int startHeight
@@ -192,7 +192,7 @@ public class GenerateTreeBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("rl <root-length>")
+    @Command("rl <root-length>")
     public void onBrushRl(
             final @NotNull Snipe snipe,
             final @Argument("root-length") @Range(min = "0") int rootLength
@@ -206,7 +206,7 @@ public class GenerateTreeBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("ts <slope-chance>")
+    @Command("ts <slope-chance>")
     public void onBrushTs(
             final @NotNull Snipe snipe,
             final @Argument("slope-chance") @Range(min = "0", max = "100") int slopeChance
@@ -220,7 +220,7 @@ public class GenerateTreeBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("bl <branch-length>")
+    @Command("bl <branch-length>")
     public void onBrushBl(
             final @NotNull Snipe snipe,
             final @Argument("branch-length") @Range(min = "0") int branchLength
@@ -234,7 +234,7 @@ public class GenerateTreeBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("minr <min-roots>")
+    @Command("minr <min-roots>")
     public void onBrushMinr(
             final @NotNull Snipe snipe,
             final @Argument("min-roots") @DynamicRange(min = "0", max = "maxRoots") int minRoots
@@ -248,7 +248,7 @@ public class GenerateTreeBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("maxr <max-roots>")
+    @Command("maxr <max-roots>")
     public void onBrushMaxr(
             final @NotNull Snipe snipe,
             final @Argument("max-roots") @DynamicRange(min = "minRoots") int maxRoots
@@ -262,7 +262,7 @@ public class GenerateTreeBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("minh <height-min>")
+    @Command("minh <height-min>")
     public void onBrushMinh(
             final @NotNull Snipe snipe,
             final @Argument("height-min") @DynamicRange(min = "0", max = "heightMax") int heightMin
@@ -276,7 +276,7 @@ public class GenerateTreeBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("maxh <height-max>")
+    @Command("maxh <height-max>")
     public void onBrushMaxh(
             final @NotNull Snipe snipe,
             final @Argument("height-max") @DynamicRange(min = "heightMin") int heightMax
@@ -290,7 +290,7 @@ public class GenerateTreeBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("minl <node-min>")
+    @Command("minl <node-min>")
     public void onBrushMinl(
             final @NotNull Snipe snipe,
             final @Argument("node-min") @DynamicRange(min = "0", max = "nodeMax") int nodeMin
@@ -304,7 +304,7 @@ public class GenerateTreeBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("maxl <node-max>")
+    @Command("maxl <node-max>")
     public void onBrushMaxl(
             final @NotNull Snipe snipe,
             final @Argument("node-max") @DynamicRange(min = "nodeMin") int nodeMax

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/HeatRayBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/HeatRayBrush.java
@@ -1,10 +1,10 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Liberal;
-import cloud.commandframework.annotations.specifier.Range;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Liberal;
+import org.incendo.cloud.annotation.specifier.Range;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockCategories;
@@ -27,8 +27,8 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Random;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b heat_ray|heatray|hr")
-@CommandPermission("voxelsniper.brush.heatray")
+@Command(value = "brush|b heat_ray|heatray|hr")
+@Permission("voxelsniper.brush.heatray")
 public class HeatRayBrush extends AbstractBrush {
 
     private static final double REQUIRED_OBSIDIAN_DENSITY = 0.6;
@@ -86,21 +86,21 @@ public class HeatRayBrush extends AbstractBrush {
         this.amplitude = getDoubleProperty("default-amplitude", DEFAULT_AMPLITUDE);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.heat-ray.info"));
     }
 
-    @CommandMethod("<soul-fire>")
+    @Command("<soul-fire>")
     public void onBrushSoulfire(
             final @NotNull Snipe snipe,
             final @Argument("soul-fire") @Liberal boolean soulFire
@@ -114,7 +114,7 @@ public class HeatRayBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("oct <octaves>")
+    @Command("oct <octaves>")
     public void onBrushOct(
             final @NotNull Snipe snipe,
             final @Argument("octaves") @Range(min = "0") int octaves
@@ -128,7 +128,7 @@ public class HeatRayBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("amp <amplitude>")
+    @Command("amp <amplitude>")
     public void onBrushAmp(
             final @NotNull Snipe snipe,
             final @Argument("amplitude") double amplitude
@@ -142,7 +142,7 @@ public class HeatRayBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("freq <frequency>")
+    @Command("freq <frequency>")
     public void onBrushFreq(
             final @NotNull Snipe snipe,
             final @Argument("frequency") double frequency

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/JockeyBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/JockeyBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Liberal;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Liberal;
 import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
@@ -27,8 +27,8 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b jockey")
-@CommandPermission("voxelsniper.brush.jockey")
+@Command(value = "brush|b jockey")
+@Permission("voxelsniper.brush.jockey")
 public class JockeyBrush extends AbstractBrush {
 
     private static final int ENTITY_STACK_LIMIT = 50;
@@ -48,21 +48,21 @@ public class JockeyBrush extends AbstractBrush {
         this.jockeyType = (JockeyType) getEnumProperty("default-jockey-type", JockeyType.class, DEFAULT_JOCKEY_TYPE);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.jockey.info"));
     }
 
-    @CommandMethod("t <jockey-type>")
+    @Command("t <jockey-type>")
     public void onBrushT(
             final @NotNull Snipe snipe,
             final @NotNull @Argument("jockey-type") JockeyType jockeyType
@@ -76,7 +76,7 @@ public class JockeyBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("<player-only> <inverse> <stack>")
+    @Command("<player-only> <inverse> <stack>")
     public void onBrushJockeytype(
             final @NotNull Snipe snipe,
             final @Argument("player-only") @Liberal boolean playerOnly,

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/LightningBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/LightningBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
@@ -12,11 +12,11 @@ import org.bukkit.World;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b lightning|light")
-@CommandPermission("voxelsniper.brush.lightning")
+@Command(value = "brush|b lightning|light")
+@Permission("voxelsniper.brush.lightning")
 public class LightningBrush extends AbstractBrush {
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/MoveBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/MoveBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.World;
@@ -20,8 +20,8 @@ import java.util.List;
  * Moves a selection blockPositionY a certain amount.
  */
 @RequireToolkit
-@CommandMethod(value = "brush|b move|mv")
-@CommandPermission("voxelsniper.brush.move")
+@Command(value = "brush|b move|mv")
+@Permission("voxelsniper.brush.move")
 public class MoveBrush extends AbstractBrush {
 
     private static final int MAX_BLOCK_COUNT = 5000000;
@@ -43,21 +43,21 @@ public class MoveBrush extends AbstractBrush {
         this.maxBlockCount = getIntegerProperty("max-block-count", MAX_BLOCK_COUNT);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.move.info"));
     }
 
-    @CommandMethod("reset")
+    @Command("reset")
     public void onBrushReset(
             final @NotNull Snipe snipe
     ) {
@@ -80,7 +80,7 @@ public class MoveBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("x <x-direction>")
+    @Command("x <x-direction>")
     public void onBrushX(
             final @NotNull Snipe snipe,
             final @Argument("x-direction") int xDirection
@@ -94,7 +94,7 @@ public class MoveBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("y <y-direction>")
+    @Command("y <y-direction>")
     public void onBrushY(
             final @NotNull Snipe snipe,
             final @Argument("y-direction") int yDirection
@@ -108,7 +108,7 @@ public class MoveBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("z <z-direction>")
+    @Command("z <z-direction>")
     public void onBrushZ(
             final @NotNull Snipe snipe,
             final @Argument("z-direction") int zDirection

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/OceanBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/OceanBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Liberal;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Liberal;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -22,8 +22,8 @@ import com.thevoxelbox.voxelsniper.util.message.VoxelSniperText;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b ocean|o")
-@CommandPermission("voxelsniper.brush.ocean")
+@Command(value = "brush|b ocean|o")
+@Permission("voxelsniper.brush.ocean")
 public class OceanBrush extends AbstractBrush {
 
     private static final int WATER_LEVEL_MIN = 12;
@@ -63,21 +63,21 @@ public class OceanBrush extends AbstractBrush {
         this.waterLevel = getIntegerProperty("default-water-lever", DEFAULT_WATER_LEVEL);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.ocean.info"));
     }
 
-    @CommandMethod("wlevel <water-level>")
+    @Command("wlevel <water-level>")
     public void onBrushWlevel(
             final @NotNull Snipe snipe,
             final @Argument("water-level") @DynamicRange(min = "waterLevelMin") int waterLevel
@@ -91,7 +91,7 @@ public class OceanBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("cfloor <cover-floor>")
+    @Command("cfloor <cover-floor>")
     public void onBrushCfloor(
             final @NotNull Snipe snipe,
             final @Argument("cover-floor") @Liberal boolean coverFloor

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/PaintingBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/PaintingBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.thevoxelbox.voxelsniper.command.argument.annotation.RequireToolkit;
 import com.thevoxelbox.voxelsniper.sniper.Sniper;
 import com.thevoxelbox.voxelsniper.sniper.snipe.Snipe;
@@ -13,11 +13,11 @@ import org.jetbrains.annotations.NotNull;
  * Painting scrolling Brush.
  */
 @RequireToolkit
-@CommandMethod(value = "brush|b painting|paint")
-@CommandPermission("voxelsniper.brush.painting")
+@Command(value = "brush|b painting|paint")
+@Permission("voxelsniper.brush.painting")
 public class PaintingBrush extends AbstractBrush {
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/PullBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/PullBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -19,8 +19,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b pull")
-@CommandPermission("voxelsniper.brush.pull")
+@Command(value = "brush|b pull")
+@Permission("voxelsniper.brush.pull")
 public class PullBrush extends AbstractBrush {
 
     private static final int DEFAULT_PINCH = 1;
@@ -38,21 +38,21 @@ public class PullBrush extends AbstractBrush {
         this.bubble = getIntegerProperty("default-bubble", DEFAULT_BUBBLE);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.pull.info"));
     }
 
-    @CommandMethod("<pinch> <bubble>")
+    @Command("<pinch> <bubble>")
     public void onBrushPinchbubble(
             final @NotNull Snipe snipe,
             final @Argument("pinch") double pinch,

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/RandomErodeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/RandomErodeBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
@@ -15,8 +15,8 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Random;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b random_erode|randomerode|re")
-@CommandPermission("voxelsniper.brush.randomerode")
+@Command(value = "brush|b random_erode|randomerode|re")
+@Permission("voxelsniper.brush.randomerode")
 public class RandomErodeBrush extends AbstractBrush {
 
     private static final double TRUE_CIRCLE = 0.5;
@@ -29,7 +29,7 @@ public class RandomErodeBrush extends AbstractBrush {
     private int erodeRecursions;
     private int fillRecursions;
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/RegenerateChunkBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/RegenerateChunkBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
@@ -21,8 +21,8 @@ import java.util.List;
  * Regenerates the target chunk.
  */
 @RequireToolkit
-@CommandMethod(value = "brush|b regenerate_chunk|regeneratechunk|rc")
-@CommandPermission("voxelsniper.brush.ellipsoid")
+@Command(value = "brush|b regenerate_chunk|regeneratechunk|rc")
+@Permission("voxelsniper.brush.ellipsoid")
 public class RegenerateChunkBrush extends AbstractBrush {
 
     private static final String DEFAULT_BIOME = "default";
@@ -33,21 +33,21 @@ public class RegenerateChunkBrush extends AbstractBrush {
 
     private BiomeType biomeType = null;
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.regenerate-chunk.info"));
     }
 
-    @CommandMethod("list")
+    @Command("list")
     public void onBrushList(
             final @NotNull Snipe snipe
     ) {
@@ -62,7 +62,7 @@ public class RegenerateChunkBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("default")
+    @Command("default")
     public void onBrushDefault(
             final @NotNull Snipe snipe
     ) {
@@ -75,7 +75,7 @@ public class RegenerateChunkBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("<biome-type>")
+    @Command("<biome-type>")
     public void onBrushBiometype(
             final @NotNull Snipe snipe,
             final @NotNull @Argument("biome-type") BiomeType biomeType

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/RulerBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/RulerBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.thevoxelbox.voxelsniper.command.argument.annotation.RequireToolkit;
@@ -12,8 +12,8 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b ruler|r")
-@CommandPermission("voxelsniper.brush.ruler")
+@Command(value = "brush|b ruler|r")
+@Permission("voxelsniper.brush.ruler")
 public class RulerBrush extends AbstractBrush {
 
     private static final int DEFAULT_X_OFFSET = 0;
@@ -27,21 +27,21 @@ public class RulerBrush extends AbstractBrush {
     private int yOffset = DEFAULT_Y_OFFSET;
     private int zOffset = DEFAULT_Z_OFFSET;
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.ruler.info"));
     }
 
-    @CommandMethod("ruler")
+    @Command("ruler")
     public void onBrushRuler(
             final @NotNull Snipe snipe
     ) {
@@ -53,7 +53,7 @@ public class RulerBrush extends AbstractBrush {
         messenger.sendMessage(Caption.of("voxelsniper.brush.ruler.ruler-mode"));
     }
 
-    @CommandMethod("<x-offset> <y-offset> <z-offset>")
+    @Command("<x-offset> <y-offset> <z-offset>")
     public void onBrushOffsets(
             final @NotNull Snipe snipe,
             final @Argument("x-offset") int xOffset,

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ScannerBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/ScannerBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -16,8 +16,8 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b scanner|sc")
-@CommandPermission("voxelsniper.brush.scanner")
+@Command(value = "brush|b scanner|sc")
+@Permission("voxelsniper.brush.scanner")
 public class ScannerBrush extends AbstractBrush {
 
     private static final int DEPTH_MIN = 1;
@@ -39,21 +39,21 @@ public class ScannerBrush extends AbstractBrush {
         this.depth = getIntegerProperty("default-depth", DEFAULT_DEPTH);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.scanner.info"));
     }
 
-    @CommandMethod("d <depth>")
+    @Command("d <depth>")
     public void onBrushD(
             final @NotNull Snipe snipe,
             final @Argument("depth") @DynamicRange(min = "depthMin", max = "depthMax") int depth

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/SignOverwriteBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/SignOverwriteBrush.java
@@ -1,11 +1,11 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Greedy;
-import cloud.commandframework.annotations.specifier.Liberal;
-import cloud.commandframework.annotations.specifier.Range;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Greedy;
+import org.incendo.cloud.annotation.specifier.Liberal;
+import org.incendo.cloud.annotation.specifier.Range;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.platform.Capability;
@@ -41,8 +41,8 @@ import java.util.Arrays;
 import java.util.List;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b sign_overwrite|signoverwrite|sio")
-@CommandPermission("voxelsniper.brush.signoverwrite")
+@Command(value = "brush|b sign_overwrite|signoverwrite|sio")
+@Permission("voxelsniper.brush.signoverwrite")
 public class SignOverwriteBrush extends AbstractBrush {
 
     private static final Side DEFAULT_SIDE = Side.FRONT;
@@ -70,21 +70,21 @@ public class SignOverwriteBrush extends AbstractBrush {
         this.side = (Side) getEnumProperty("default-side", Side.class, DEFAULT_SIDE);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.sign-overwrite.info"));
     }
 
-    @CommandMethod("list")
+    @Command("list")
     public void onBrushList(
             final @NotNull Snipe snipe
     ) {
@@ -99,7 +99,7 @@ public class SignOverwriteBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("clear|c")
+    @Command("clear|c")
     public void onBrushClear(
             final @NotNull Snipe snipe
     ) {
@@ -109,7 +109,7 @@ public class SignOverwriteBrush extends AbstractBrush {
         messenger.sendMessage(Caption.of("voxelsniper.brush.sign-overwrite.cleared"));
     }
 
-    @CommandMethod("clearall|ca")
+    @Command("clearall|ca")
     public void onBrushClearall(
             final @NotNull Snipe snipe
     ) {
@@ -120,7 +120,7 @@ public class SignOverwriteBrush extends AbstractBrush {
         messenger.sendMessage(Caption.of("voxelsniper.brush.sign-overwrite.cleared-reset"));
     }
 
-    @CommandMethod("side <side>")
+    @Command("side <side>")
     public void onBrushSide(
             final @NotNull Snipe snipe,
             final @NotNull @Argument("side") Side side
@@ -139,7 +139,7 @@ public class SignOverwriteBrush extends AbstractBrush {
     }
 
     @SuppressWarnings("deprecation") // Paper deprecation
-    @CommandMethod("<line> set <text>")
+    @Command("<line> set <text>")
     public void onBrushLineSet(
             final @NotNull Snipe snipe,
             final @Argument("line") @Range(min = "1", max = "4") int line,
@@ -169,7 +169,7 @@ public class SignOverwriteBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("<line> toggle")
+    @Command("<line> toggle")
     public void onBrushLineToggle(
             final @NotNull Snipe snipe,
             final @Argument("line") @Range(min = "1", max = "4") int line
@@ -185,7 +185,7 @@ public class SignOverwriteBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("multiple|m <ranged-mode>")
+    @Command("multiple|m <ranged-mode>")
     public void onBrushMultiple(
             final @NotNull Snipe snipe,
             final @Argument("ranged-mode") @Liberal boolean rangedMode
@@ -210,7 +210,7 @@ public class SignOverwriteBrush extends AbstractBrush {
         }
     }
 
-    @CommandMethod("save|s <sign>")
+    @Command("save|s <sign>")
     public void onBrushSave(
             final @NotNull Snipe snipe,
             final @NotNull @Argument(value = "sign", parserName = "sign-file_parser") File sign
@@ -218,7 +218,7 @@ public class SignOverwriteBrush extends AbstractBrush {
         this.saveBufferToFile(snipe, sign);
     }
 
-    @CommandMethod("open|o <sign>")
+    @Command("open|o <sign>")
     public void onBrushOpen(
             final @NotNull Snipe snipe,
             final @NotNull @Argument(value = "sign", parserName = "sign-file_parser") File sign

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/SnowConeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/SnowConeBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.fastasyncworldedit.core.registry.state.PropertyKey;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -16,11 +16,11 @@ import com.thevoxelbox.voxelsniper.util.material.Materials;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b snow_cone|snowcone|snow")
-@CommandPermission("voxelsniper.brush.snowcone")
+@Command(value = "brush|b snow_cone|snowcone|snow")
+@Permission("voxelsniper.brush.snowcone")
 public class SnowConeBrush extends AbstractBrush {
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/SpiralStaircaseBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/SpiralStaircaseBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.fastasyncworldedit.core.registry.state.PropertyKey;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -17,8 +17,8 @@ import com.thevoxelbox.voxelsniper.util.material.Materials;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b spiral_staircase|spiralstaircase|sstair")
-@CommandPermission("voxelsniper.brush.spiralstaircase")
+@Command(value = "brush|b spiral_staircase|spiralstaircase|sstair")
+@Permission("voxelsniper.brush.spiralstaircase")
 public class SpiralStaircaseBrush extends AbstractBrush {
 
     private static final String DEFAULT_SDIRECT = "c";
@@ -33,14 +33,14 @@ public class SpiralStaircaseBrush extends AbstractBrush {
         this.sopen = getStringProperty("default-sopen", DEFAULT_SOPEN);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
@@ -57,14 +57,14 @@ public class SpiralStaircaseBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("c")
+    @Command("c")
     public void onBrushC(
             final @NotNull Snipe snipe
     ) {
         this.onBrushSdirectCommand(snipe, "c");
     }
 
-    @CommandMethod("cc")
+    @Command("cc")
     public void onBrushCc(
             final @NotNull Snipe snipe
     ) {
@@ -81,28 +81,28 @@ public class SpiralStaircaseBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("n")
+    @Command("n")
     public void onBrushN(
             final @NotNull Snipe snipe
     ) {
         this.onBrushSopenCommand(snipe, "n");
     }
 
-    @CommandMethod("e")
+    @Command("e")
     public void onBrushE(
             final @NotNull Snipe snipe
     ) {
         this.onBrushSopenCommand(snipe, "e");
     }
 
-    @CommandMethod("s")
+    @Command("s")
     public void onBrushS(
             final @NotNull Snipe snipe
     ) {
         this.onBrushSopenCommand(snipe, "s");
     }
 
-    @CommandMethod("w")
+    @Command("w")
     public void onBrushW(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/TreeSnipeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/TreeSnipeBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -21,8 +21,8 @@ import java.util.List;
 import java.util.stream.IntStream;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b tree_snipe|treesnipe|tree|t")
-@CommandPermission("voxelsniper.brush.treesnipe")
+@Command(value = "brush|b tree_snipe|treesnipe|tree|t")
+@Permission("voxelsniper.brush.treesnipe")
 public class TreeSnipeBrush extends AbstractBrush {
 
     private static final TreeGenerator.TreeType DEFAULT_TREE_TYPE = TreeGenerator.TreeType.TREE;
@@ -36,21 +36,21 @@ public class TreeSnipeBrush extends AbstractBrush {
         );
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.tree-snipe.info"));
     }
 
-    @CommandMethod("list")
+    @Command("list")
     public void onBrushList(
             final @NotNull Snipe snipe
     ) {
@@ -65,7 +65,7 @@ public class TreeSnipeBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("<tree-type>")
+    @Command("<tree-type>")
     public void onBrushTreetype(
             final @NotNull Snipe snipe,
             final @NotNull @Argument("tree-type") TreeGenerator.TreeType treeType

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/VoltmeterBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/VoltmeterBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
@@ -19,11 +19,11 @@ import org.bukkit.block.BlockFace;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b voltmeter|volt")
-@CommandPermission("voxelsniper.brush.voltmeter")
+@Command(value = "brush|b voltmeter|volt")
+@Permission("voxelsniper.brush.voltmeter")
 public class VoltmeterBrush extends AbstractBrush {
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/WarpBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/WarpBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.Fawe;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -14,11 +14,11 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b warp|world")
-@CommandPermission("voxelsniper.brush.warp")
+@Command(value = "brush|b warp|world")
+@Permission("voxelsniper.brush.warp")
 public class WarpBrush extends AbstractBrush {
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/blend/BlendBallBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/blend/BlendBallBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type.blend;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockType;
@@ -18,25 +18,25 @@ import java.util.Map;
 import java.util.Set;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b blend_ball|blendball|bb")
-@CommandPermission("voxelsniper.brush.blendball")
+@Command(value = "brush|b blend_ball|blendball|bb")
+@Permission("voxelsniper.brush.blendball")
 public class BlendBallBrush extends AbstractBlendBrush {
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.blend-ball.info"));
     }
 
-    @CommandMethod("water")
+    @Command("water")
     public void onBrushWater(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/blend/BlendDiscBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/blend/BlendDiscBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type.blend;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockType;
@@ -18,25 +18,25 @@ import java.util.Map;
 import java.util.Set;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b blend_disc|blenddisc|bd")
-@CommandPermission("voxelsniper.brush.blenddisc")
+@Command(value = "brush|b blend_disc|blenddisc|bd")
+@Permission("voxelsniper.brush.blenddisc")
 public class BlendDiscBrush extends AbstractBlendBrush {
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.blend-disc.info"));
     }
 
-    @CommandMethod("water")
+    @Command("water")
     public void onBrushWater(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/blend/BlendVoxelBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/blend/BlendVoxelBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type.blend;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockType;
@@ -18,25 +18,25 @@ import java.util.Map;
 import java.util.Set;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b blend_voxel|blendvoxel|bv")
-@CommandPermission("voxelsniper.brush.blendvoxel")
+@Command(value = "brush|b blend_voxel|blendvoxel|bv")
+@Permission("voxelsniper.brush.blendvoxel")
 public class BlendVoxelBrush extends AbstractBlendBrush {
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.blend-voxel.info"));
     }
 
-    @CommandMethod("water")
+    @Command("water")
     public void onBrushWater(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/blend/BlendVoxelDiscBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/blend/BlendVoxelDiscBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type.blend;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockType;
@@ -18,25 +18,25 @@ import java.util.Map;
 import java.util.Set;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b blend_voxel_disc|blendvoxeldisc|bvd")
-@CommandPermission("voxelsniper.brush.blendvoxeldisc")
+@Command(value = "brush|b blend_voxel_disc|blendvoxeldisc|bvd")
+@Permission("voxelsniper.brush.blendvoxeldisc")
 public class BlendVoxelDiscBrush extends AbstractBlendBrush {
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.blend-voxel-disc.info"));
     }
 
-    @CommandMethod("water")
+    @Command("water")
     public void onBrushWater(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/canyon/CanyonBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/canyon/CanyonBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type.canyon;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -16,8 +16,8 @@ import com.thevoxelbox.voxelsniper.sniper.snipe.message.SnipeMessenger;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b canyon|ca")
-@CommandPermission("voxelsniper.brush.canyon")
+@Command(value = "brush|b canyon|ca")
+@Permission("voxelsniper.brush.canyon")
 public class CanyonBrush extends AbstractBrush {
 
     private static final int SHIFT_LEVEL_MIN = -54;
@@ -38,21 +38,21 @@ public class CanyonBrush extends AbstractBrush {
         this.yLevel = getIntegerProperty("default-y-level", DEFAULT_Y_LEVEL);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.canyon.info"));
     }
 
-    @CommandMethod("y <y-level>")
+    @Command("y <y-level>")
     public void onBrushY(
             final @NotNull Snipe snipe,
             final @Argument("y-level") @DynamicRange(min = "shiftLevelMin", max = "shiftLevelMax") int yLevel

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/canyon/CanyonSelectionBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/canyon/CanyonSelectionBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type.canyon;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.thevoxelbox.voxelsniper.command.argument.annotation.DynamicRange;
@@ -12,29 +12,29 @@ import com.thevoxelbox.voxelsniper.sniper.snipe.message.SnipeMessenger;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b canyon_selection|canyonselection|cas")
-@CommandPermission("voxelsniper.brush.canyonselection")
+@Command(value = "brush|b canyon_selection|canyonselection|cas")
+@Permission("voxelsniper.brush.canyonselection")
 public class CanyonSelectionBrush extends CanyonBrush {
 
     private boolean first = true;
     private int fx;
     private int fz;
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrush(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfo(snipe);
     }
 
-    @CommandMethod("y <y-level>")
+    @Command("y <y-level>")
     public void onBrushY(
             final @NotNull Snipe snipe,
             final @Argument("y-level") @DynamicRange(min = "shiftLevelMin", max = "shiftLevelMax") int yLevel

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type.entity;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.sk89q.worldedit.EditSession;
@@ -22,8 +22,8 @@ import org.bukkit.World;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b entity|en")
-@CommandPermission("voxelsniper.brush.entity")
+@Command(value = "brush|b entity|en")
+@Permission("voxelsniper.brush.entity")
 public class EntityBrush extends AbstractBrush {
 
     private static final EntityType DEFAULT_ENTITY_TYPE = EntityTypes.ZOMBIE;
@@ -35,21 +35,21 @@ public class EntityBrush extends AbstractBrush {
         this.entityType = (EntityType) getRegistryProperty("default-entity-type", EntityType.REGISTRY, DEFAULT_ENTITY_TYPE);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.entity.info"));
     }
 
-    @CommandMethod("list")
+    @Command("list")
     public void onBrushList(
             final @NotNull Snipe snipe
     ) {
@@ -64,7 +64,7 @@ public class EntityBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("<entity-type>")
+    @Command("<entity-type>")
     public void onBrushEntitytype(
             final @NotNull Snipe snipe,
             final @NotNull @Argument("entity-type") EntityType entityType

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityRemovalBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/entity/EntityRemovalBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type.entity;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
@@ -24,8 +24,8 @@ import java.util.Arrays;
 import java.util.List;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b entity_removal|entityremoval|er")
-@CommandPermission("voxelsniper.brush.entityremoval")
+@Command(value = "brush|b entity_removal|entityremoval|er")
+@Permission("voxelsniper.brush.entityremoval")
 public class EntityRemovalBrush extends AbstractBrush {
 
     private static final List<String> DEFAULT_EXEMPTIONS = Arrays.asList(
@@ -44,21 +44,21 @@ public class EntityRemovalBrush extends AbstractBrush {
         );
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.entity.removal"));
     }
 
-    @CommandMethod("list")
+    @Command("list")
     public void onBrushList(
             final @NotNull Snipe snipe
     ) {
@@ -71,7 +71,7 @@ public class EntityRemovalBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("add <entity-class>")
+    @Command("add <entity-class>")
     public void onBrushPlus(
             final @NotNull Snipe snipe,
             final @NotNull @Argument(value = "entity-class", parserName = "entity-class_parser") Class<? extends Entity> entityClass
@@ -85,7 +85,7 @@ public class EntityRemovalBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("remove <entity-class>")
+    @Command("remove <entity-class>")
     public void onBrushMinus(
             final @NotNull Snipe snipe,
             final @NotNull @Argument(value = "entity-class", parserName = "entity-class_parser") Class<? extends Entity> entityClass

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/BallBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/BallBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Liberal;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Liberal;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -19,8 +19,8 @@ import org.jetbrains.annotations.NotNull;
  * A brush that creates a solid ball.
  */
 @RequireToolkit
-@CommandMethod(value = "brush|b ball|b")
-@CommandPermission("voxelsniper.brush.ball")
+@Command(value = "brush|b ball|b")
+@Permission("voxelsniper.brush.ball")
 public class BallBrush extends AbstractPerformerBrush {
 
     private boolean trueCircle;
@@ -29,21 +29,21 @@ public class BallBrush extends AbstractPerformerBrush {
     public void loadProperties() {
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.performer-brush.ball.info"));
     }
 
-    @CommandMethod("<true-circle>")
+    @Command("<true-circle>")
     public void onBrushTruecircle(
             final @NotNull Snipe snipe,
             final @Argument("true-circle") @Liberal boolean trueCircle

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/BlobBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/BlobBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.thevoxelbox.voxelsniper.command.argument.annotation.DynamicRange;
@@ -13,8 +13,8 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b blob|splatblob")
-@CommandPermission("voxelsniper.brush.blob")
+@Command(value = "brush|b blob|splatblob")
+@Permission("voxelsniper.brush.blob")
 public class BlobBrush extends AbstractPerformerBrush {
 
     @Override
@@ -25,14 +25,14 @@ public class BlobBrush extends AbstractPerformerBrush {
         this.growthPercent = getIntegerProperty("default-growth-percent", DEFAULT_GROWTH_PERCENT);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
@@ -41,7 +41,7 @@ public class BlobBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("g <growth-percent>")
+    @Command("g <growth-percent>")
     public void onBrushG(
             final @NotNull Snipe snipe,
             final @Argument("growth-percent") @DynamicRange(min = "growthPercentMin", max = "growthPercentMax") int growthPercent

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/CheckerVoxelDiscBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/CheckerVoxelDiscBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Liberal;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Liberal;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.thevoxelbox.voxelsniper.command.argument.annotation.RequireToolkit;
@@ -14,8 +14,8 @@ import com.thevoxelbox.voxelsniper.util.message.VoxelSniperText;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b checker_voxel_disc|checkervoxeldisc|cvd")
-@CommandPermission("voxelsniper.brush.checkervoxeldisc")
+@Command(value = "brush|b checker_voxel_disc|checkervoxeldisc|cvd")
+@Permission("voxelsniper.brush.checkervoxeldisc")
 public class CheckerVoxelDiscBrush extends AbstractPerformerBrush {
 
     private boolean useWorldCoordinates = true;
@@ -24,21 +24,21 @@ public class CheckerVoxelDiscBrush extends AbstractPerformerBrush {
     public void loadProperties() {
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.performer-brush.checker-voxel-disc.info"));
     }
 
-    @CommandMethod("<use-world-coordinates>")
+    @Command("<use-world-coordinates>")
     public void onBrushUseworldcoordinates(
             final @NotNull Snipe snipe,
             final @Argument("use-world-coordinates") @Liberal boolean useWorldCoordinates

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/CylinderBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/CylinderBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Liberal;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Liberal;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -15,8 +15,8 @@ import com.thevoxelbox.voxelsniper.util.message.VoxelSniperText;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b cylinder|c")
-@CommandPermission("voxelsniper.brush.cylinder")
+@Command(value = "brush|b cylinder|c")
+@Permission("voxelsniper.brush.cylinder")
 public class CylinderBrush extends AbstractPerformerBrush {
 
     private boolean trueCircle;
@@ -25,21 +25,21 @@ public class CylinderBrush extends AbstractPerformerBrush {
     public void loadProperties() {
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.performer-brush.cylinder.info"));
     }
 
-    @CommandMethod("<true-circle>")
+    @Command("<true-circle>")
     public void onBrushTruecircle(
             final @NotNull Snipe snipe,
             final @Argument("true-circle") @Liberal boolean trueCircle
@@ -53,7 +53,7 @@ public class CylinderBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("h <height>")
+    @Command("h <height>")
     public void onBrushH(
             final @NotNull Snipe snipe,
             final @Argument("height") int height
@@ -68,7 +68,7 @@ public class CylinderBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("c <center>")
+    @Command("c <center>")
     public void onBrushC(
             final @NotNull Snipe snipe,
             final @Argument("center") int center

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/EllipseBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/EllipseBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -15,8 +15,8 @@ import com.thevoxelbox.voxelsniper.util.message.VoxelSniperText;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b ellipse|el")
-@CommandPermission("voxelsniper.brush.ellipse")
+@Command(value = "brush|b ellipse|el")
+@Permission("voxelsniper.brush.ellipse")
 public class EllipseBrush extends AbstractPerformerBrush {
 
     private static final double TWO_PI = (2 * Math.PI);
@@ -53,21 +53,21 @@ public class EllipseBrush extends AbstractPerformerBrush {
         this.steps = getIntegerProperty("default-steps", DEFAULT_STEPS);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.performer-brush.ellipse.info"));
     }
 
-    @CommandMethod("fill")
+    @Command("fill")
     public void onBrushFill(
             final @NotNull Snipe snipe
     ) {
@@ -80,7 +80,7 @@ public class EllipseBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("x <x-scl>")
+    @Command("x <x-scl>")
     public void onBrushX(
             final @NotNull Snipe snipe,
             final @Argument("x-scl") @DynamicRange(min = "sclMin", max = "sclMax") int xscl
@@ -94,7 +94,7 @@ public class EllipseBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("y <y-scl>")
+    @Command("y <y-scl>")
     public void onBrushY(
             final @NotNull Snipe snipe,
             final @Argument("y-scl") @DynamicRange(min = "sclMin", max = "sclMax") int yscl
@@ -108,7 +108,7 @@ public class EllipseBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("t <steps>")
+    @Command("t <steps>")
     public void onBrushT(
             final @NotNull Snipe snipe,
             final @Argument("steps") @DynamicRange(min = "stepsMin", max = "stepsMax") int steps

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/EllipsoidBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/EllipsoidBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Liberal;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Liberal;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.thevoxelbox.voxelsniper.command.argument.annotation.RequireToolkit;
@@ -13,8 +13,8 @@ import com.thevoxelbox.voxelsniper.util.message.VoxelSniperText;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b ellipsoid|elo")
-@CommandPermission("voxelsniper.brush.ellipsoid")
+@Command(value = "brush|b ellipsoid|elo")
+@Permission("voxelsniper.brush.ellipsoid")
 public class EllipsoidBrush extends AbstractPerformerBrush {
 
     private static final int DEFAULT_X_RAD = 0;
@@ -27,21 +27,21 @@ public class EllipsoidBrush extends AbstractPerformerBrush {
     private double yRad = DEFAULT_Y_RAD;
     private double zRad = DEFAULT_Z_RAD;
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.performer-brush.ellipsoid.info"));
     }
 
-    @CommandMethod("<offset>")
+    @Command("<offset>")
     public void onBrushOffset(
             final @NotNull Snipe snipe,
             final @Argument("offset") @Liberal boolean offset
@@ -55,7 +55,7 @@ public class EllipsoidBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("x <x-rad>")
+    @Command("x <x-rad>")
     public void onBrushX(
             final @NotNull Snipe snipe,
             final @Argument("x-rad") int xRad
@@ -69,7 +69,7 @@ public class EllipsoidBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("y <y-rad>")
+    @Command("y <y-rad>")
     public void onBrushY(
             final @NotNull Snipe snipe,
             final @Argument("y-rad") int yRad
@@ -83,7 +83,7 @@ public class EllipsoidBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("z <z-rad>")
+    @Command("z <z-rad>")
     public void onBrushZ(
             final @NotNull Snipe snipe,
             final @Argument("z-rad") int zRad

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/FillDownBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/FillDownBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Liberal;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Liberal;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -17,8 +17,8 @@ import com.thevoxelbox.voxelsniper.util.message.VoxelSniperText;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b fill_down|filldown|fd")
-@CommandPermission("voxelsniper.brush.filldown")
+@Command(value = "brush|b fill_down|filldown|fd")
+@Permission("voxelsniper.brush.filldown")
 public class FillDownBrush extends AbstractPerformerBrush {
 
     private boolean trueCircle;
@@ -33,14 +33,14 @@ public class FillDownBrush extends AbstractPerformerBrush {
         }
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
@@ -50,7 +50,7 @@ public class FillDownBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("<true-circle>")
+    @Command("<true-circle>")
     public void onBrushTruecircle(
             final @NotNull Snipe snipe,
             final @Argument("true-circle") @Liberal boolean trueCircle
@@ -64,7 +64,7 @@ public class FillDownBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("all")
+    @Command("all")
     public void onBrushAll(
             final @NotNull Snipe snipe
     ) {
@@ -77,7 +77,7 @@ public class FillDownBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("some")
+    @Command("some")
     public void onBrushSome(
             final @NotNull Snipe snipe
     ) {
@@ -92,7 +92,7 @@ public class FillDownBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("e")
+    @Command("e")
     public void onBrushE(
             final @NotNull Snipe snipe
     ) {
@@ -112,7 +112,7 @@ public class FillDownBrush extends AbstractPerformerBrush {
         }
     }
 
-    @CommandMethod("y <min-y>")
+    @Command("y <min-y>")
     public void onBrushY(
             final @NotNull Snipe snipe,
             final @Argument("min-y") int minY

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/JaggedLineBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/JaggedLineBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Range;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Range;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -22,8 +22,8 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Random;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b jagged_line|jaggedline|jagged|j")
-@CommandPermission("voxelsniper.brush.jaggedline")
+@Command(value = "brush|b jagged_line|jaggedline|jagged|j")
+@Permission("voxelsniper.brush.jaggedline")
 public class JaggedLineBrush extends AbstractPerformerBrush {
 
     private static final Vector HALF_BLOCK_OFFSET = new Vector(0.5, 0.5, 0.5);
@@ -53,14 +53,14 @@ public class JaggedLineBrush extends AbstractPerformerBrush {
         this.spread = getIntegerProperty("default-spread", DEFAULT_SPREAD);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
@@ -73,7 +73,7 @@ public class JaggedLineBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("r <recursions>")
+    @Command("r <recursions>")
     public void onBrushR(
             final @NotNull Snipe snipe,
             final @Argument("recursions") @DynamicRange(min = "recursionMin", max = "recursionMax") int recursions
@@ -87,7 +87,7 @@ public class JaggedLineBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("s <spread>")
+    @Command("s <spread>")
     public void onBrushS(
             final @NotNull Snipe snipe,
             final @Argument("spread") @Range(min = "0") int spread

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/LineBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/LineBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
@@ -18,8 +18,8 @@ import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b line|l")
-@CommandPermission("voxelsniper.brush.line")
+@Command(value = "brush|b line|l")
+@Permission("voxelsniper.brush.line")
 public class LineBrush extends AbstractPerformerBrush {
 
     private static final Vector HALF_BLOCK_OFFSET = new Vector(0.5, 0.5, 0.5);
@@ -32,14 +32,14 @@ public class LineBrush extends AbstractPerformerBrush {
     public void loadProperties() {
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/OverlayBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/OverlayBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Range;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Range;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -19,8 +19,8 @@ import com.thevoxelbox.voxelsniper.util.message.VoxelSniperText;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b overlay|over")
-@CommandPermission("overlay")
+@Command(value = "brush|b overlay|over")
+@Permission("overlay")
 public class OverlayBrush extends AbstractPerformerBrush {
 
     private static final int DEFAULT_DEPTH = 3;
@@ -34,21 +34,21 @@ public class OverlayBrush extends AbstractPerformerBrush {
         this.depth = getIntegerProperty("default-depth", DEFAULT_DEPTH);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.performer-brush.overlay.info"));
     }
 
-    @CommandMethod("all")
+    @Command("all")
     public void onBrushAll(
             final @NotNull Snipe snipe
     ) {
@@ -61,7 +61,7 @@ public class OverlayBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("some")
+    @Command("some")
     public void onBrushSome(
             final @NotNull Snipe snipe
     ) {
@@ -74,7 +74,7 @@ public class OverlayBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("d <depth>")
+    @Command("d <depth>")
     public void onBrushD(
             final @NotNull Snipe snipe,
             final @Argument("depth") @Range(min = "1") int depth

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/PunishBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/PunishBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
@@ -32,8 +32,8 @@ import java.util.Locale;
 import java.util.Random;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b punish|p")
-@CommandPermission("voxelsniper.brush.punish")
+@Command(value = "brush|b punish|p")
+@Permission("voxelsniper.brush.punish")
 public class PunishBrush extends AbstractPerformerBrush {
 
     private static final int TICKS_PER_SECOND = 20;
@@ -71,21 +71,21 @@ public class PunishBrush extends AbstractPerformerBrush {
         this.punishDuration = getIntegerProperty("default-punish-duration", DEFAULT_PUNISH_DURATION);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.performer-brush.punish.info"));
     }
 
-    @CommandMethod("list")
+    @Command("list")
     public void onBrushList(
             final @NotNull Snipe snipe
     ) {
@@ -100,7 +100,7 @@ public class PunishBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("toggleSelf")
+    @Command("toggleSelf")
     public void onBrushToggleself(
             final @NotNull Snipe snipe
     ) {
@@ -114,7 +114,7 @@ public class PunishBrush extends AbstractPerformerBrush {
         }
     }
 
-    @CommandMethod("toggleHypnoLandscape")
+    @Command("toggleHypnoLandscape")
     public void onBrushToggleHypnoLandscape(
             final @NotNull Snipe snipe
     ) {
@@ -127,7 +127,7 @@ public class PunishBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("<punishment>")
+    @Command("<punishment>")
     public void onBrushPunishment(
             final @NotNull Snipe snipe,
             final @NotNull @Argument("punishment") Punishment punishment
@@ -141,7 +141,7 @@ public class PunishBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("toggleSM <player>")
+    @Command("toggleSM <player>")
     public void onBrushTogglesm(
             final @NotNull Snipe snipe,
             final @NotNull @Argument("player") Player player

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/RingBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/RingBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Liberal;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Liberal;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.thevoxelbox.voxelsniper.command.argument.annotation.RequireToolkit;
@@ -14,8 +14,8 @@ import com.thevoxelbox.voxelsniper.util.message.VoxelSniperText;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b ring|ri")
-@CommandPermission("voxelsniper.brush.ring")
+@Command(value = "brush|b ring|ri")
+@Permission("voxelsniper.brush.ring")
 public class RingBrush extends AbstractPerformerBrush {
 
     private static final double DEFAULT_INNER_SIZE = 0.0;
@@ -24,21 +24,21 @@ public class RingBrush extends AbstractPerformerBrush {
 
     private double innerSize = DEFAULT_INNER_SIZE;
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.performer-brush.ring.info"));
     }
 
-    @CommandMethod("<true-circle>")
+    @Command("<true-circle>")
     public void onBrushTruecircle(
             final @NotNull Snipe snipe,
             final @Argument("true-circle") @Liberal boolean trueCircle
@@ -52,7 +52,7 @@ public class RingBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("ir <inner-size>")
+    @Command("ir <inner-size>")
     public void onBrushIr(
             final @NotNull Snipe snipe,
             final @Argument("inner-size") double innerSize

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/SetBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/SetBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.World;
@@ -12,8 +12,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b set")
-@CommandPermission("voxelsniper.brush.set")
+@Command(value = "brush|b set")
+@Permission("voxelsniper.brush.set")
 public class SetBrush extends AbstractPerformerBrush {
 
     private static final int SELECTION_SIZE_MAX = 5000000;
@@ -29,7 +29,7 @@ public class SetBrush extends AbstractPerformerBrush {
         this.selectionSizeMax = getIntegerProperty("selection-size-max", SELECTION_SIZE_MAX);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/SnipeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/SnipeBrush.java
@@ -1,22 +1,22 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.thevoxelbox.voxelsniper.command.argument.annotation.RequireToolkit;
 import com.thevoxelbox.voxelsniper.sniper.snipe.Snipe;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b snipe|s")
-@CommandPermission("voxelsniper.brush.snipe")
+@Command(value = "brush|b snipe|s")
+@Permission("voxelsniper.brush.snipe")
 public class SnipeBrush extends AbstractPerformerBrush {
 
     @Override
     public void loadProperties() {
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/SplineBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/SplineBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.thevoxelbox.voxelsniper.command.argument.annotation.RequireToolkit;
@@ -18,8 +18,8 @@ import java.util.List;
  * the splines will be included.
  */
 @RequireToolkit
-@CommandMethod(value = "brush|b spline|sp")
-@CommandPermission("voxelsniper.brush.ellipsoid")
+@Command(value = "brush|b spline|sp")
+@Permission("voxelsniper.brush.ellipsoid")
 public class SplineBrush extends AbstractPerformerBrush {
 
     private final List<BlockVector3> endPts = new ArrayList<>();
@@ -32,21 +32,21 @@ public class SplineBrush extends AbstractPerformerBrush {
     public void loadProperties() {
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.performer-brush.spline.info"));
     }
 
-    @CommandMethod("ss")
+    @Command("ss")
     public void onBrushSs(
             final @NotNull Snipe snipe
     ) {
@@ -62,7 +62,7 @@ public class SplineBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("sc")
+    @Command("sc")
     public void onBrushSc(
             final @NotNull Snipe snipe
     ) {
@@ -78,14 +78,14 @@ public class SplineBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("clear")
+    @Command("clear")
     public void onBrushClear(
             final @NotNull Snipe snipe
     ) {
         this.clear(snipe);
     }
 
-    @CommandMethod("ren")
+    @Command("ren")
     public void onBrushRen(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/ThreePointCircleBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/ThreePointCircleBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
@@ -19,8 +19,8 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b three_point_circle|threepointcircle|tpc")
-@CommandPermission("voxelsniper.brush.threepointcircle")
+@Command(value = "brush|b three_point_circle|threepointcircle|tpc")
+@Permission("voxelsniper.brush.threepointcircle")
 public class ThreePointCircleBrush extends AbstractPerformerBrush {
 
     private static final Tolerance DEFAULT_TOLERANCE = Tolerance.DEFAULT;
@@ -39,21 +39,21 @@ public class ThreePointCircleBrush extends AbstractPerformerBrush {
         this.tolerance = (Tolerance) getEnumProperty("default-tolerance", Tolerance.class, DEFAULT_TOLERANCE);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.performer-brush.three-point-circle.info"));
     }
 
-    @CommandMethod("list")
+    @Command("list")
     public void onBrushList(
             final @NotNull Snipe snipe
     ) {
@@ -68,7 +68,7 @@ public class ThreePointCircleBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("<tolerance>")
+    @Command("<tolerance>")
     public void onBrushTolerance(
             final @NotNull Snipe snipe,
             final @NotNull @Argument("tolerance") Tolerance tolerance

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/TriangleBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/TriangleBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.thevoxelbox.voxelsniper.command.argument.annotation.RequireToolkit;
@@ -14,8 +14,8 @@ import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b triangle|tri")
-@CommandPermission("voxelsniper.brush.triangle")
+@Command(value = "brush|b triangle|tri")
+@Permission("voxelsniper.brush.triangle")
 public class TriangleBrush extends AbstractPerformerBrush {
 
     private final double[] coordinatesOne = new double[3]; // Three corners
@@ -32,14 +32,14 @@ public class TriangleBrush extends AbstractPerformerBrush {
     public void loadProperties() {
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/UnderlayBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/UnderlayBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Range;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Range;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockType;
@@ -17,8 +17,8 @@ import com.thevoxelbox.voxelsniper.util.message.VoxelSniperText;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b underlay|under")
-@CommandPermission("voxelsniper.brush.underlay")
+@Command(value = "brush|b underlay|under")
+@Permission("voxelsniper.brush.underlay")
 public class UnderlayBrush extends AbstractPerformerBrush {
 
     private static final int DEFAULT_DEPTH = 3;
@@ -32,21 +32,21 @@ public class UnderlayBrush extends AbstractPerformerBrush {
         this.depth = getIntegerProperty("default-depth", DEFAULT_DEPTH);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.performer-brush.underlay.info"));
     }
 
-    @CommandMethod("all")
+    @Command("all")
     public void onBrushAll(
             final @NotNull Snipe snipe
     ) {
@@ -59,7 +59,7 @@ public class UnderlayBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("some")
+    @Command("some")
     public void onBrushSome(
             final @NotNull Snipe snipe
     ) {
@@ -72,7 +72,7 @@ public class UnderlayBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("d <depth>")
+    @Command("d <depth>")
     public void onBrushD(
             final @NotNull Snipe snipe,
             final @Argument("depth") @Range(min = "1") int depth

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/VoxelBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/VoxelBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.thevoxelbox.voxelsniper.command.argument.annotation.RequireToolkit;
 import com.thevoxelbox.voxelsniper.sniper.snipe.Snipe;
@@ -9,15 +9,15 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b voxel|v")
-@CommandPermission("voxelsniper.brush.voxel")
+@Command(value = "brush|b voxel|v")
+@Permission("voxelsniper.brush.voxel")
 public class VoxelBrush extends AbstractPerformerBrush {
 
     @Override
     public void loadProperties() {
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/disc/DiscBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/disc/DiscBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer.disc;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Liberal;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Liberal;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.fastasyncworldedit.core.math.MutableBlockVector3;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -16,8 +16,8 @@ import com.thevoxelbox.voxelsniper.util.message.VoxelSniperText;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b disc|d")
-@CommandPermission("voxelsniper.brush.disc")
+@Command(value = "brush|b disc|d")
+@Permission("voxelsniper.brush.disc")
 public class DiscBrush extends AbstractPerformerBrush {
 
     private boolean trueCircle;
@@ -26,21 +26,21 @@ public class DiscBrush extends AbstractPerformerBrush {
     public void loadProperties() {
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.disc.info"));
     }
 
-    @CommandMethod("<true-circle>")
+    @Command("<true-circle>")
     public void onBrushTruecircle(
             final @NotNull Snipe snipe,
             final @Argument("true-circle") @Liberal boolean trueCircle

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/disc/DiscFaceBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/disc/DiscFaceBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer.disc;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Liberal;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Liberal;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Direction;
@@ -16,8 +16,8 @@ import com.thevoxelbox.voxelsniper.util.message.VoxelSniperText;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b disc_face|discface|df")
-@CommandPermission("voxelsniper.brush.discface")
+@Command(value = "brush|b disc_face|discface|df")
+@Permission("voxelsniper.brush.discface")
 public class DiscFaceBrush extends AbstractPerformerBrush {
 
     private boolean trueCircle;
@@ -26,21 +26,21 @@ public class DiscFaceBrush extends AbstractPerformerBrush {
     public void loadProperties() {
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.disc-face.info"));
     }
 
-    @CommandMethod("<true-circle>")
+    @Command("<true-circle>")
     public void onBrushTruecircle(
             final @NotNull Snipe snipe,
             final @Argument("true-circle") @Liberal boolean trueCircle

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/disc/VoxelDiscBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/disc/VoxelDiscBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer.disc;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.thevoxelbox.voxelsniper.brush.type.performer.AbstractPerformerBrush;
 import com.thevoxelbox.voxelsniper.command.argument.annotation.RequireToolkit;
@@ -10,15 +10,15 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b voxel_disc|voxeldisc|vd")
-@CommandPermission("voxelsniper.brush.voxel_disc")
+@Command(value = "brush|b voxel_disc|voxeldisc|vd")
+@Permission("voxelsniper.brush.voxel_disc")
 public class VoxelDiscBrush extends AbstractPerformerBrush {
 
     @Override
     public void loadProperties() {
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/disc/VoxelDiscFaceBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/disc/VoxelDiscFaceBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer.disc;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Direction;
 import com.thevoxelbox.voxelsniper.brush.type.performer.AbstractPerformerBrush;
@@ -11,15 +11,15 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b voxel_disc_face|voxeldiscface|vdf")
-@CommandPermission("voxelsniper.brush.voxel_disc")
+@Command(value = "brush|b voxel_disc_face|voxeldiscface|vdf")
+@Permission("voxelsniper.brush.voxel_disc")
 public class VoxelDiscFaceBrush extends AbstractPerformerBrush {
 
     @Override
     public void loadProperties() {
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterBallBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterBallBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer.splatter;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.thevoxelbox.voxelsniper.brush.type.performer.AbstractPerformerBrush;
@@ -14,25 +14,25 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b splatter_ball|splatterball|sb")
-@CommandPermission("voxelsniper.brush.splatterball")
+@Command(value = "brush|b splatter_ball|splatterball|sb")
+@Permission("voxelsniper.brush.splatterball")
 public class SplatterBallBrush extends AbstractPerformerBrush {
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.splatter-ball.info"));
     }
 
-    @CommandMethod("s <seed-percent>")
+    @Command("s <seed-percent>")
     public void onBrushS(
             final @NotNull Snipe snipe,
             final @Argument("seed-percent") @DynamicRange(min = "seedPercentMin", max = "seedPercentMax") int seedPercent
@@ -46,7 +46,7 @@ public class SplatterBallBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("g <growth-percent>")
+    @Command("g <growth-percent>")
     public void onBrushG(
             final @NotNull Snipe snipe,
             final @Argument("growth-percent") @DynamicRange(min = "growthPercentMin", max = "growthPercentMax") int growthPercent
@@ -60,7 +60,7 @@ public class SplatterBallBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("r <splatter-recursions>")
+    @Command("r <splatter-recursions>")
     public void onBrushR(
             final @NotNull Snipe snipe,
             final @Argument("splatter-recursions") @DynamicRange(min = "splatterRecursionsMin", max = "splatterRecursionsMax") int splatterRecursions

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterDiscBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterDiscBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer.splatter;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.thevoxelbox.voxelsniper.brush.type.performer.AbstractPerformerBrush;
@@ -14,25 +14,25 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b splatter_disc|splatterdisc|sd")
-@CommandPermission("voxelsniper.brush.splatterdisc")
+@Command(value = "brush|b splatter_disc|splatterdisc|sd")
+@Permission("voxelsniper.brush.splatterdisc")
 public class SplatterDiscBrush extends AbstractPerformerBrush {
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.splatter-disc.info"));
     }
 
-    @CommandMethod("s <seed-percent>")
+    @Command("s <seed-percent>")
     public void onBrushS(
             final @NotNull Snipe snipe,
             final @Argument("seed-percent") @DynamicRange(min = "seedPercentMin", max = "seedPercentMax") int seedPercent
@@ -46,7 +46,7 @@ public class SplatterDiscBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("g <growth-percent>")
+    @Command("g <growth-percent>")
     public void onBrushG(
             final @NotNull Snipe snipe,
             final @Argument("growth-percent") @DynamicRange(min = "growthPercentMin", max = "growthPercentMax") int growthPercent
@@ -60,7 +60,7 @@ public class SplatterDiscBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("r <splatter-recursions>")
+    @Command("r <splatter-recursions>")
     public void onBrushR(
             final @NotNull Snipe snipe,
             final @Argument("splatter-recursions") @DynamicRange(min = "splatterRecursionsMin", max = "splatterRecursionsMax") int splatterRecursions

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterOverlayBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterOverlayBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer.splatter;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Range;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Range;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -21,8 +21,8 @@ import com.thevoxelbox.voxelsniper.util.message.VoxelSniperText;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b splatter_overlay|splatteroverlay|sover")
-@CommandPermission("voxelsniper.brush.splatteroverlay")
+@Command(value = "brush|b splatter_overlay|splatteroverlay|sover")
+@Permission("voxelsniper.brush.splatteroverlay")
 public class SplatterOverlayBrush extends AbstractPerformerBrush {
 
     private static final int DEFAULT_DEPTH = 3;
@@ -41,21 +41,21 @@ public class SplatterOverlayBrush extends AbstractPerformerBrush {
         this.yOffset = getIntegerProperty("default-y-offset", DEFAULT_Y_OFFSET);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.splatter-overlay.info"));
     }
 
-    @CommandMethod("all")
+    @Command("all")
     public void onBrushAll(
             final @NotNull Snipe snipe
     ) {
@@ -68,7 +68,7 @@ public class SplatterOverlayBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("some")
+    @Command("some")
     public void onBrushSome(
             final @NotNull Snipe snipe
     ) {
@@ -81,7 +81,7 @@ public class SplatterOverlayBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("randh")
+    @Command("randh")
     public void onBrushRandh(
             final @NotNull Snipe snipe
     ) {
@@ -94,7 +94,7 @@ public class SplatterOverlayBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("d <depth>")
+    @Command("d <depth>")
     public void onBrushD(
             final @NotNull Snipe snipe,
             final @Argument("depth") @Range(min = "1") int depth
@@ -108,7 +108,7 @@ public class SplatterOverlayBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("s <seed-percent>")
+    @Command("s <seed-percent>")
     public void onBrushS(
             final @NotNull Snipe snipe,
             final @Argument("seed-percent") @DynamicRange(min = "seedPercentMin", max = "seedPercentMax") int seedPercent
@@ -122,7 +122,7 @@ public class SplatterOverlayBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("g <growth-percent>")
+    @Command("g <growth-percent>")
     public void onBrushG(
             final @NotNull Snipe snipe,
             final @Argument("growth-percent") @DynamicRange(min = "growthPercentMin", max = "growthPercentMax") int growthPercent
@@ -136,7 +136,7 @@ public class SplatterOverlayBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("r <splatter-recursions>")
+    @Command("r <splatter-recursions>")
     public void onBrushR(
             final @NotNull Snipe snipe,
             final @Argument("splatter-recursions") @DynamicRange(min = "splatterRecursionsMin", max = "splatterRecursionsMax") int splatterRecursions
@@ -150,7 +150,7 @@ public class SplatterOverlayBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("yoff <y-offset>")
+    @Command("yoff <y-offset>")
     public void onBrushY(
             final @NotNull Snipe snipe,
             final @Argument("y-offset") int yOffset

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterVoxelBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterVoxelBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer.splatter;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.thevoxelbox.voxelsniper.brush.type.performer.AbstractPerformerBrush;
@@ -14,25 +14,25 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b splatter_voxel|splattervoxel|sv")
-@CommandPermission("voxelsniper.brush.splattervoxel")
+@Command(value = "brush|b splatter_voxel|splattervoxel|sv")
+@Permission("voxelsniper.brush.splattervoxel")
 public class SplatterVoxelBrush extends AbstractPerformerBrush {
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.splatter-voxel.info"));
     }
 
-    @CommandMethod("s <seed-percent>")
+    @Command("s <seed-percent>")
     public void onBrushS(
             final @NotNull Snipe snipe,
             final @Argument("seed-percent") @DynamicRange(min = "seedPercentMin", max = "seedPercentMax") int seedPercent
@@ -46,7 +46,7 @@ public class SplatterVoxelBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("g <growth-percent>")
+    @Command("g <growth-percent>")
     public void onBrushG(
             final @NotNull Snipe snipe,
             final @Argument("growth-percent") @DynamicRange(min = "growthPercentMin", max = "growthPercentMax") int growthPercent
@@ -60,7 +60,7 @@ public class SplatterVoxelBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("r <splatter-recursions>")
+    @Command("r <splatter-recursions>")
     public void onBrushR(
             final @NotNull Snipe snipe,
             final @Argument("splatter-recursions") @DynamicRange(min = "splatterRecursionsMin", max = "splatterRecursionsMax") int splatterRecursions

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterVoxelDiscBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/performer/splatter/SplatterVoxelDiscBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type.performer.splatter;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.thevoxelbox.voxelsniper.brush.type.performer.AbstractPerformerBrush;
@@ -14,25 +14,25 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b splatter_voxel_disc|splattervoxeldisc|svd")
-@CommandPermission("voxelsniper.brush.splattervoxel")
+@Command(value = "brush|b splatter_voxel_disc|splattervoxeldisc|svd")
+@Permission("voxelsniper.brush.splattervoxel")
 public class SplatterVoxelDiscBrush extends AbstractPerformerBrush {
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.splatter-voxel-disc.info"));
     }
 
-    @CommandMethod("s <seed-percent>")
+    @Command("s <seed-percent>")
     public void onBrushS(
             final @NotNull Snipe snipe,
             final @Argument("seed-percent") @DynamicRange(min = "seedPercentMin", max = "seedPercentMax") int seedPercent
@@ -46,7 +46,7 @@ public class SplatterVoxelDiscBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("g <growth-percent>")
+    @Command("g <growth-percent>")
     public void onBrushG(
             final @NotNull Snipe snipe,
             final @Argument("growth-percent") @DynamicRange(min = "growthPercentMin", max = "growthPercentMax") int growthPercent
@@ -60,7 +60,7 @@ public class SplatterVoxelDiscBrush extends AbstractPerformerBrush {
         ));
     }
 
-    @CommandMethod("r <splatter-recursions>")
+    @Command("r <splatter-recursions>")
     public void onBrushR(
             final @NotNull Snipe snipe,
             final @Argument("splatter-recursions") @DynamicRange(min = "splatterRecursionsMin", max = "splatterRecursionsMax") int splatterRecursions

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/redstone/SetRedstoneFlipBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/redstone/SetRedstoneFlipBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type.redstone;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.fastasyncworldedit.core.registry.state.PropertyKey;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -17,29 +17,29 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b set_redstone_flip|setredstoneflip|setrf")
-@CommandPermission("voxelsniper.brush.setredstoneflip")
+@Command(value = "brush|b set_redstone_flip|setredstoneflip|setrf")
+@Permission("voxelsniper.brush.setredstoneflip")
 public class SetRedstoneFlipBrush extends AbstractBrush {
 
     @Nullable
     private BlockVector3 block;
     private boolean northSouth = true;
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.set-redstone-flip.info"));
     }
 
-    @CommandMethod("ns|n|s")
+    @Command("ns|n|s")
     public void onBrushNs(
             final @NotNull Snipe snipe
     ) {
@@ -49,7 +49,7 @@ public class SetRedstoneFlipBrush extends AbstractBrush {
         messenger.sendMessage(Caption.of("voxelsniper.brush.set-redstone-flip.north-south"));
     }
 
-    @CommandMethod("ew|e|w")
+    @Command("ew|e|w")
     public void onBrushEw(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/redstone/SetRedstoneRotateBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/redstone/SetRedstoneRotateBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type.redstone;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.fastasyncworldedit.core.registry.state.PropertyKey;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -17,14 +17,14 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b set_redstone_rotate|setredstonerotatep|setrr")
-@CommandPermission("voxelsniper.brush.setredstonerotate")
+@Command(value = "brush|b set_redstone_rotate|setredstonerotatep|setrr")
+@Permission("voxelsniper.brush.setredstonerotate")
 public class SetRedstoneRotateBrush extends AbstractBrush {
 
     @Nullable
     private BlockVector3 block;
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type.rotation;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Range;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Range;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -18,8 +18,8 @@ import com.thevoxelbox.voxelsniper.util.material.Materials;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b rotation_2d|rotation2d|rot2d|rot2")
-@CommandPermission("voxelsniper.brush.rot2d")
+@Command(value = "brush|b rotation_2d|rotation2d|rot2d|rot2")
+@Permission("voxelsniper.brush.rot2d")
 public class Rotation2DBrush extends AbstractBrush {
 
     private static final int DEFAULT_ANGLE = 0;
@@ -29,14 +29,14 @@ public class Rotation2DBrush extends AbstractBrush {
 
     private double angle = DEFAULT_ANGLE;
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
@@ -45,7 +45,7 @@ public class Rotation2DBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("<degrees-angle>")
+    @Command("<degrees-angle>")
     public void onBrushDegreesangle(
             final @NotNull Snipe snipe,
             final @Argument("degrees-angle") @Range(min = "0", max = "360") int degreesAngle

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DVerticalBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation2DVerticalBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type.rotation;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Range;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Range;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -20,8 +20,8 @@ import org.jetbrains.annotations.NotNull;
 // The X Y and Z variable names in this file do NOT MAKE ANY SENSE. Do not attempt to actually figure out what on earth is going on here. Just go to the
 // original 2d horizontal brush if you wish to make anything similar to this, and start there. I didn't bother renaming everything.
 @RequireToolkit
-@CommandMethod(value = "brush|b rotation_2d_vert|rotation2dvert|rot2dv|rot2v")
-@CommandPermission("voxelsniper.brush.rot2dvert")
+@Command(value = "brush|b rotation_2d_vert|rotation2dvert|rot2dv|rot2v")
+@Permission("voxelsniper.brush.rot2dvert")
 public class Rotation2DVerticalBrush extends AbstractBrush {
 
     private static final int DEFAULT_ANGLE = 0;
@@ -31,14 +31,14 @@ public class Rotation2DVerticalBrush extends AbstractBrush {
 
     private double angle = DEFAULT_ANGLE;
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
@@ -47,7 +47,7 @@ public class Rotation2DVerticalBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("<degrees-angle>")
+    @Command("<degrees-angle>")
     public void onBrushDegreesangle(
             final @NotNull Snipe snipe,
             final @Argument("degrees-angle") @Range(min = "0", max = "360") int degreesAngle

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation3DBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/rotation/Rotation3DBrush.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.brush.type.rotation;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Range;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Range;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -18,8 +18,8 @@ import com.thevoxelbox.voxelsniper.util.material.Materials;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b rotation_3d|rotation3d|rot3d|rot3")
-@CommandPermission("voxelsniper.brush.rot3d")
+@Command(value = "brush|b rotation_3d|rotation3d|rot3d|rot3")
+@Permission("voxelsniper.brush.rot3d")
 public class Rotation3DBrush extends AbstractBrush {
 
     private static final int DEFAULT_SE_YAW = 0;
@@ -33,14 +33,14 @@ public class Rotation3DBrush extends AbstractBrush {
     private double sePitch = DEFAULT_SE_PITCH;
     private double seRoll = DEFAULT_SE_ROLL;
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
@@ -49,7 +49,7 @@ public class Rotation3DBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("p <degrees-angle>")
+    @Command("p <degrees-angle>")
     public void onBrushP(
             final @NotNull Snipe snipe,
             final @Argument("degrees-angle") @Range(min = "0", max = "360") int degreesAngle
@@ -64,7 +64,7 @@ public class Rotation3DBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("r <degrees-angle>")
+    @Command("r <degrees-angle>")
     public void onBrushR(
             final @NotNull Snipe snipe,
             final @Argument("degrees-angle") @Range(min = "0", max = "360") int degreesAngle
@@ -79,7 +79,7 @@ public class Rotation3DBrush extends AbstractBrush {
         ));
     }
 
-    @CommandMethod("y <degrees-angle>")
+    @Command("y <degrees-angle>")
     public void onBrushY(
             final @NotNull Snipe snipe,
             final @Argument("degrees-angle") @Range(min = "0", max = "360") int degreesAngle

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/shell/ShellBallBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/shell/ShellBallBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type.shell;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -14,11 +14,11 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b shell_ball|shellball|shb")
-@CommandPermission("voxelsniper.brush.shellball")
+@Command(value = "brush|b shell_ball|shellball|shb")
+@Permission("voxelsniper.brush.shellball")
 public class ShellBallBrush extends AbstractBrush {
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/shell/ShellSetBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/shell/ShellSetBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type.shell;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -19,8 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b shell_set|shellset|shs")
-@CommandPermission("voxelsniper.brush.shellset")
+@Command(value = "brush|b shell_set|shellset|shs")
+@Permission("voxelsniper.brush.shellset")
 public class ShellSetBrush extends AbstractBrush {
 
     private static final int MAX_SIZE = 5000000;
@@ -35,7 +35,7 @@ public class ShellSetBrush extends AbstractBrush {
         this.maxSize = getIntegerProperty("max-size", MAX_SIZE);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/shell/ShellVoxelBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/shell/ShellVoxelBrush.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.brush.type.shell;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -14,11 +14,11 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b shell_voxel|shellvoxel|shv")
-@CommandPermission("voxelsniper.brush.shellvoxel")
+@Command(value = "brush|b shell_voxel|shellvoxel|shv")
+@Permission("voxelsniper.brush.shellvoxel")
 public class ShellVoxelBrush extends AbstractBrush {
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stamp/CloneStampBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stamp/CloneStampBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type.stamp;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -16,8 +16,8 @@ import org.jetbrains.annotations.NotNull;
  * The CloneStamp class is used to create a collection of blocks in a cylinder shape according to the selection the player has set.
  */
 @RequireToolkit
-@CommandMethod(value = "brush|b clone_stamp|clonestamp|cs")
-@CommandPermission("voxelsniper.brush.clonestamp")
+@Command(value = "brush|b clone_stamp|clonestamp|cs")
+@Permission("voxelsniper.brush.clonestamp")
 public class CloneStampBrush extends AbstractStampBrush {
 
     private static final StampType DEFAULT_STAMP_TYPE = StampType.DEFAULT;
@@ -27,21 +27,21 @@ public class CloneStampBrush extends AbstractStampBrush {
         this.stamp = ((StampType) getEnumProperty("default-stamp-type", StampType.class, DEFAULT_STAMP_TYPE));
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
         super.onBrushInfoCommand(snipe, Caption.of("voxelsniper.brush.clone-stamp.info"));
     }
 
-    @CommandMethod("<stamp-type>")
+    @Command("<stamp-type>")
     public void onBrushStamptype(
             final @NotNull Snipe snipe,
             final @NotNull @Argument("stamp-type") StampType stampType
@@ -56,28 +56,28 @@ public class CloneStampBrush extends AbstractStampBrush {
         ));
     }
 
-    @CommandMethod("a")
+    @Command("a")
     public void onBrushA(
             final @NotNull Snipe snipe
     ) {
         this.onBrushStamptype(snipe, StampType.NO_AIR);
     }
 
-    @CommandMethod("f")
+    @Command("f")
     public void onBrushF(
             final @NotNull Snipe snipe
     ) {
         this.onBrushStamptype(snipe, StampType.FILL);
     }
 
-    @CommandMethod("d")
+    @Command("d")
     public void onBrushD(
             final @NotNull Snipe snipe
     ) {
         this.onBrushStamptype(snipe, StampType.DEFAULT);
     }
 
-    @CommandMethod("c <center>")
+    @Command("c <center>")
     public void onBrushC(
             final @NotNull Snipe snipe,
             final @Argument("center") int center

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type.stencil;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -33,8 +33,8 @@ import java.io.IOException;
  * block. First byte is ID, second is data. This applies to every one of the line of consecutive blocks if boolean was true.)
  */
 @RequireToolkit
-@CommandMethod(value = "brush|b stencil|st")
-@CommandPermission("voxelsniper.brush.stencil")
+@Command(value = "brush|b stencil|st")
+@Permission("voxelsniper.brush.stencil")
 public class StencilBrush extends AbstractBrush {
 
     private static final int DEFAULT_PASTE_OPTION = 1;
@@ -64,14 +64,14 @@ public class StencilBrush extends AbstractBrush {
         this.maxSaveVolume = getIntegerProperty("default-max-save-volume", DEFAULT_MAX_SAVE_VOLUME);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
@@ -96,7 +96,7 @@ public class StencilBrush extends AbstractBrush {
         }
     }
 
-    @CommandMethod("full <stencil>")
+    @Command("full <stencil>")
     public void onBrushFull(
             final @NotNull Snipe snipe,
             final @NotNull @Argument(value = "stencil", parserName = "stencil-file_parser") File stencil
@@ -104,7 +104,7 @@ public class StencilBrush extends AbstractBrush {
         this.onBrushPasteCommand(snipe, (byte) 0, stencil);
     }
 
-    @CommandMethod("fill <stencil>")
+    @Command("fill <stencil>")
     public void onBrushFill(
             final @NotNull Snipe snipe,
             final @NotNull @Argument(value = "stencil", parserName = "stencil-file_parser") File stencil
@@ -112,7 +112,7 @@ public class StencilBrush extends AbstractBrush {
         this.onBrushPasteCommand(snipe, (byte) 1, stencil);
     }
 
-    @CommandMethod("replace <stencil>")
+    @Command("replace <stencil>")
     public void onBrushReplace(
             final @NotNull Snipe snipe,
             final @NotNull @Argument(value = "stencil", parserName = "stencil-file_parser") File stencil
@@ -120,7 +120,7 @@ public class StencilBrush extends AbstractBrush {
         this.onBrushPasteCommand(snipe, (byte) 2, stencil);
     }
 
-    @CommandMethod("<stencil>")
+    @Command("<stencil>")
     public void onBrushStencil(
             final @NotNull Snipe snipe,
             final @NotNull @Argument(value = "stencil", parserName = "stencil-file_parser") File stencil

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilListBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/type/stencil/StencilListBrush.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.brush.type.stencil;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -24,8 +24,8 @@ import java.util.Map;
 import java.util.Scanner;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b stencil_list|stencillist|sl")
-@CommandPermission("voxelsniper.brush.stencillist")
+@Command(value = "brush|b stencil_list|stencillist|sl")
+@Permission("voxelsniper.brush.stencillist")
 public class StencilListBrush extends AbstractBrush {
 
     private static final String NO_FILE_LOADED = "NoFileLoaded";
@@ -47,14 +47,14 @@ public class StencilListBrush extends AbstractBrush {
         this.pasteOption = (byte) getIntegerProperty("default-paste-option", DEFAULT_PASTE_OPTION);
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Snipe snipe
     ) {
         super.onBrushCommand(snipe);
     }
 
-    @CommandMethod("info")
+    @Command("info")
     public void onBrushInfo(
             final @NotNull Snipe snipe
     ) {
@@ -81,7 +81,7 @@ public class StencilListBrush extends AbstractBrush {
         }
     }
 
-    @CommandMethod("full <stencil-list>")
+    @Command("full <stencil-list>")
     public void onBrushFull(
             final @NotNull Snipe snipe,
             final @NotNull @Argument(value = "stencil-list", parserName = "stencil-list-file_parser") File stencilList
@@ -89,7 +89,7 @@ public class StencilListBrush extends AbstractBrush {
         this.onBrushPasteCommand(snipe, (byte) 0, stencilList);
     }
 
-    @CommandMethod("fill <stencil-list>")
+    @Command("fill <stencil-list>")
     public void onBrushFill(
             final @NotNull Snipe snipe,
             final @NotNull @Argument(value = "stencil-list", parserName = "stencil-list-file_parser") File stencilList
@@ -97,7 +97,7 @@ public class StencilListBrush extends AbstractBrush {
         this.onBrushPasteCommand(snipe, (byte) 1, stencilList);
     }
 
-    @CommandMethod("replace <stencil-list>")
+    @Command("replace <stencil-list>")
     public void onBrushReplace(
             final @NotNull Snipe snipe,
             final @NotNull @Argument(value = "stencil-list", parserName = "stencil-list-file_parser") File stencilList
@@ -105,7 +105,7 @@ public class StencilListBrush extends AbstractBrush {
         this.onBrushPasteCommand(snipe, (byte) 2, stencilList);
     }
 
-    @CommandMethod("<stencil-list>")
+    @Command("<stencil-list>")
     public void onBrushStencillist(
             final @NotNull Snipe snipe,
             final @NotNull @Argument(value = "stencil-list", parserName = "stencil-list-file_parser") File stencilList

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelMethodCommandExecutionHandler.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelMethodCommandExecutionHandler.java
@@ -1,13 +1,16 @@
 package com.thevoxelbox.voxelsniper.command;
 
-import cloud.commandframework.annotations.MethodCommandExecutionHandler;
-import cloud.commandframework.context.CommandContext;
-import cloud.commandframework.exceptions.CommandExecutionException;
+import org.incendo.cloud.annotations.MethodCommandExecutionHandler;
+import org.incendo.cloud.annotations.method.ParameterValue;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.exception.CommandExecutionException;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
+import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class VoxelMethodCommandExecutionHandler<C> extends MethodCommandExecutionHandler<C> {
 
@@ -36,11 +39,10 @@ public class VoxelMethodCommandExecutionHandler<C> extends MethodCommandExecutio
             this.methodHandle
                     .bindTo(executorInstanceSupplier.apply(commandContext))
                     .invokeWithArguments(
-                            this.createParameterValues(
-                                    commandContext,
-                                    commandContext.flags(),
-                                    super.parameters()
-                            )
+                            this.createParameterValues(commandContext)
+                                .stream()
+                                .map(ParameterValue::value)
+                                .collect(Collectors.toList())
                     );
         } catch (final Error e) {
             throw e;

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/argument/AbstractRegistryArgument.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/argument/AbstractRegistryArgument.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.command.argument;
 
-import cloud.commandframework.context.CommandContext;
-import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.context.CommandInput;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.registry.Keyed;
 import com.sk89q.worldedit.registry.NamespacedRegistry;
@@ -9,9 +9,8 @@ import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.command.VoxelCommandElement;
 import com.thevoxelbox.voxelsniper.sniper.SniperCommander;
 
-import java.util.List;
 import java.util.Locale;
-import java.util.Queue;
+import java.util.stream.Stream;
 
 public abstract class AbstractRegistryArgument<T extends Keyed> implements VoxelCommandElement {
 
@@ -33,17 +32,12 @@ public abstract class AbstractRegistryArgument<T extends Keyed> implements Voxel
         this.parseExceptionCaptionKey = parseExceptionCaptionKey;
     }
 
-    protected List<String> suggestValues(CommandContext<SniperCommander> commandContext, String input) {
-        return registry.getSuggestions(input)
-                .toList();
+    protected Stream<String> suggestValues(CommandContext<SniperCommander> commandContext, String input) {
+        return registry.getSuggestions(input);
     }
 
-    protected T parseValue(CommandContext<SniperCommander> commandContext, Queue<String> inputQueue) {
-        String input = inputQueue.peek();
-        if (input == null) {
-            throw new NoInputProvidedException(AbstractRegistryArgument.class, commandContext);
-        }
-
+    protected T parseValue(CommandContext<SniperCommander> commandContext, CommandInput commandInput) {
+        final String input = commandInput.readString();
         T value = registry.get(input.toLowerCase(Locale.ROOT));
         if (value == null) {
             throw new VoxelCommandElementParseException(input, Caption.of(
@@ -52,7 +46,6 @@ public abstract class AbstractRegistryArgument<T extends Keyed> implements Voxel
             ));
         }
 
-        inputQueue.remove();
         return value;
     }
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/argument/BiomeTypeArgument.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/argument/BiomeTypeArgument.java
@@ -1,14 +1,14 @@
 package com.thevoxelbox.voxelsniper.command.argument;
 
-import cloud.commandframework.annotations.parsers.Parser;
-import cloud.commandframework.annotations.suggestions.Suggestions;
-import cloud.commandframework.context.CommandContext;
+import org.incendo.cloud.annotations.parser.Parser;
+import org.incendo.cloud.annotations.suggestion.Suggestions;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.context.CommandInput;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.sniper.SniperCommander;
 
-import java.util.List;
-import java.util.Queue;
+import java.util.stream.Stream;
 
 public class BiomeTypeArgument extends AbstractRegistryArgument<BiomeType> {
 
@@ -23,13 +23,13 @@ public class BiomeTypeArgument extends AbstractRegistryArgument<BiomeType> {
     }
 
     @Suggestions("biome-type_suggestions")
-    public List<String> suggestBiomeTypes(CommandContext<SniperCommander> commandContext, String input) {
+    public Stream<String> suggestBiomeTypes(CommandContext<SniperCommander> commandContext, String input) {
         return super.suggestValues(commandContext, input);
     }
 
     @Parser(suggestions = "biome-type_suggestions")
-    public BiomeType parseBiomeType(CommandContext<SniperCommander> commandContext, Queue<String> inputQueue) {
-        return super.parseValue(commandContext, inputQueue);
+    public BiomeType parseBiomeType(CommandContext<SniperCommander> commandContext, CommandInput commandInput) {
+        return super.parseValue(commandContext, commandInput);
     }
 
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/argument/BlockArgument.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/argument/BlockArgument.java
@@ -1,8 +1,9 @@
 package com.thevoxelbox.voxelsniper.command.argument;
 
-import cloud.commandframework.annotations.parsers.Parser;
-import cloud.commandframework.annotations.suggestions.Suggestions;
-import cloud.commandframework.context.CommandContext;
+import org.incendo.cloud.annotations.parser.Parser;
+import org.incendo.cloud.annotations.suggestion.Suggestions;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.context.CommandInput;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
@@ -10,7 +11,6 @@ import com.thevoxelbox.voxelsniper.brush.property.BrushPattern;
 import com.thevoxelbox.voxelsniper.sniper.SniperCommander;
 
 import java.util.List;
-import java.util.Queue;
 
 public class BlockArgument extends AbstractPatternArgument<BaseBlock> {
 
@@ -30,8 +30,8 @@ public class BlockArgument extends AbstractPatternArgument<BaseBlock> {
     }
 
     @Parser(name = "block_parser", suggestions = "block_suggestions")
-    public BrushPattern parseBlock(CommandContext<SniperCommander> commandContext, Queue<String> inputQueue) {
-        return super.parsePattern(commandContext, inputQueue);
+    public BrushPattern parseBlock(CommandContext<SniperCommander> commandContext, CommandInput commandInput) {
+        return super.parsePattern(commandContext, commandInput);
     }
 
     @Override

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/argument/BlockTypeArgument.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/argument/BlockTypeArgument.java
@@ -1,14 +1,16 @@
 package com.thevoxelbox.voxelsniper.command.argument;
 
-import cloud.commandframework.annotations.parsers.Parser;
-import cloud.commandframework.annotations.suggestions.Suggestions;
-import cloud.commandframework.context.CommandContext;
+import org.incendo.cloud.annotations.parser.Parser;
+import org.incendo.cloud.annotations.suggestion.Suggestions;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.context.CommandInput;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.sniper.SniperCommander;
 
 import java.util.List;
 import java.util.Queue;
+import java.util.stream.Stream;
 
 public class BlockTypeArgument extends AbstractRegistryArgument<BlockType> {
 
@@ -23,13 +25,13 @@ public class BlockTypeArgument extends AbstractRegistryArgument<BlockType> {
     }
 
     @Suggestions("block-type_suggestions")
-    public List<String> suggestBlockTypes(CommandContext<SniperCommander> commandContext, String input) {
+    public Stream<String> suggestBlockTypes(CommandContext<SniperCommander> commandContext, String input) {
         return super.suggestValues(commandContext, input);
     }
 
     @Parser(suggestions = "block-type_suggestions")
-    public BlockType parseBlockType(CommandContext<SniperCommander> commandContext, Queue<String> inputQueue) {
-        return super.parseValue(commandContext, inputQueue);
+    public BlockType parseBlockType(CommandContext<SniperCommander> commandContext, CommandInput commandInput) {
+        return super.parseValue(commandContext, commandInput);
     }
 
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/argument/BrushPropertiesArgument.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/argument/BrushPropertiesArgument.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.command.argument;
 
-import cloud.commandframework.annotations.parsers.Parser;
-import cloud.commandframework.annotations.suggestions.Suggestions;
-import cloud.commandframework.context.CommandContext;
-import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
+import org.incendo.cloud.annotations.parser.Parser;
+import org.incendo.cloud.annotations.suggestion.Suggestions;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.context.CommandInput;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.brush.BrushRegistry;
@@ -15,6 +15,7 @@ import org.bukkit.command.CommandSender;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.stream.Stream;
 
 public class BrushPropertiesArgument implements VoxelCommandElement {
 
@@ -33,26 +34,21 @@ public class BrushPropertiesArgument implements VoxelCommandElement {
     }
 
     @Suggestions("brush-properties_suggestions")
-    public List<String> suggestBrushProperties(CommandContext<SniperCommander> commandContext, String input) {
-        SniperCommander commander = commandContext.getSender();
+    public Stream<String> suggestBrushProperties(CommandContext<SniperCommander> commandContext, String input) {
+        SniperCommander commander = commandContext.sender();
         CommandSender sender = commander.getCommandSender();
         return brushRegistry.getBrushesProperties().entrySet().stream()
                 .filter(entry -> {
                     String permission = entry.getValue().getPermission();
                     return permission == null || sender.hasPermission(permission);
                 })
-                .map(Map.Entry::getKey)
-                .toList();
+                .map(Map.Entry::getKey);
     }
 
     @Parser(name = "brush-properties_parser", suggestions = "brush-properties_suggestions")
-    public BrushProperties parseBrushProperties(CommandContext<SniperCommander> commandContext, Queue<String> inputQueue) {
-        String input = inputQueue.peek();
-        if (input == null) {
-            throw new NoInputProvidedException(BrushPropertiesArgument.class, commandContext);
-        }
-
-        SniperCommander commander = commandContext.getSender();
+    public BrushProperties parseBrushProperties(CommandContext<SniperCommander> commandContext, CommandInput commandInput) {
+        SniperCommander commander = commandContext.sender();
+        String input = commandInput.readString();
         BrushProperties properties = brushRegistry.getBrushProperties(input);
         if (properties == null) {
             throw new VoxelCommandElementParseException(input, Caption.of(
@@ -69,7 +65,6 @@ public class BrushPropertiesArgument implements VoxelCommandElement {
             ));
         }
 
-        inputQueue.remove();
         return properties;
     }
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/argument/EntityClassArgument.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/argument/EntityClassArgument.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.command.argument;
 
-import cloud.commandframework.annotations.parsers.Parser;
-import cloud.commandframework.annotations.suggestions.Suggestions;
-import cloud.commandframework.context.CommandContext;
-import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
+import org.incendo.cloud.annotations.parser.Parser;
+import org.incendo.cloud.annotations.suggestion.Suggestions;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.context.CommandInput;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.command.VoxelCommandElement;
@@ -14,7 +14,6 @@ import org.bukkit.entity.EntityType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Queue;
 
 public class EntityClassArgument implements VoxelCommandElement {
 
@@ -57,12 +56,8 @@ public class EntityClassArgument implements VoxelCommandElement {
     }
 
     @Parser(name = "entity-class_parser", suggestions = "entity-class_suggestions")
-    public Class<? extends Entity> parseEntityClass(CommandContext<Sniper> commandContext, Queue<String> inputQueue) {
-        String input = inputQueue.peek();
-        if (input == null) {
-            throw new NoInputProvidedException(EntityClassArgument.class, commandContext);
-        }
-
+    public Class<? extends Entity> parseEntityClass(CommandContext<Sniper> commandContext, CommandInput commandInput) {
+        String input = commandInput.readString();
         Class<? extends Entity> clazz = getEntityClass(input);
         if (clazz == null) {
             throw new VoxelCommandElementParseException(input, Caption.of(
@@ -71,7 +66,6 @@ public class EntityClassArgument implements VoxelCommandElement {
             ));
         }
 
-        inputQueue.remove();
         return clazz;
     }
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/argument/EntityTypeArgument.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/argument/EntityTypeArgument.java
@@ -1,14 +1,14 @@
 package com.thevoxelbox.voxelsniper.command.argument;
 
-import cloud.commandframework.annotations.parsers.Parser;
-import cloud.commandframework.annotations.suggestions.Suggestions;
-import cloud.commandframework.context.CommandContext;
+import org.incendo.cloud.annotations.parser.Parser;
+import org.incendo.cloud.annotations.suggestion.Suggestions;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.context.CommandInput;
 import com.sk89q.worldedit.world.entity.EntityType;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.sniper.SniperCommander;
 
-import java.util.List;
-import java.util.Queue;
+import java.util.stream.Stream;
 
 public class EntityTypeArgument extends AbstractRegistryArgument<EntityType> {
 
@@ -23,13 +23,13 @@ public class EntityTypeArgument extends AbstractRegistryArgument<EntityType> {
     }
 
     @Suggestions("entity-type_suggestions")
-    public List<String> suggestEntityTypes(CommandContext<SniperCommander> commandContext, String input) {
+    public Stream<String> suggestEntityTypes(CommandContext<SniperCommander> commandContext, String input) {
         return super.suggestValues(commandContext, input);
     }
 
     @Parser(suggestions = "entity-type_suggestions")
-    public EntityType parseEntityType(CommandContext<SniperCommander> commandContext, Queue<String> inputQueue) {
-        return super.parseValue(commandContext, inputQueue);
+    public EntityType parseEntityType(CommandContext<SniperCommander> commandContext, CommandInput commandInput) {
+        return super.parseValue(commandContext, commandInput);
     }
 
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/argument/PatternArgument.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/argument/PatternArgument.java
@@ -1,15 +1,15 @@
 package com.thevoxelbox.voxelsniper.command.argument;
 
-import cloud.commandframework.annotations.parsers.Parser;
-import cloud.commandframework.annotations.suggestions.Suggestions;
-import cloud.commandframework.context.CommandContext;
+import org.incendo.cloud.annotations.parser.Parser;
+import org.incendo.cloud.annotations.suggestion.Suggestions;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.context.CommandInput;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.brush.property.BrushPattern;
 import com.thevoxelbox.voxelsniper.sniper.SniperCommander;
 
 import java.util.List;
-import java.util.Queue;
 
 public class PatternArgument extends AbstractPatternArgument<Pattern> {
 
@@ -29,8 +29,8 @@ public class PatternArgument extends AbstractPatternArgument<Pattern> {
     }
 
     @Parser(name = "pattern_parser", suggestions = "pattern_suggestions")
-    public BrushPattern parsePattern(CommandContext<SniperCommander> commandContext, Queue<String> inputQueue) {
-        return super.parsePattern(commandContext, inputQueue);
+    public BrushPattern parsePattern(CommandContext<SniperCommander> commandContext, CommandInput commandInput) {
+        return super.parsePattern(commandContext, commandInput);
     }
 
     @Override

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/argument/SignFileArgument.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/argument/SignFileArgument.java
@@ -1,14 +1,14 @@
 package com.thevoxelbox.voxelsniper.command.argument;
 
-import cloud.commandframework.annotations.parsers.Parser;
-import cloud.commandframework.annotations.suggestions.Suggestions;
-import cloud.commandframework.context.CommandContext;
+import org.incendo.cloud.annotations.parser.Parser;
+import org.incendo.cloud.annotations.suggestion.Suggestions;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.context.CommandInput;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.sniper.SniperCommander;
 
 import java.io.File;
-import java.util.List;
-import java.util.Queue;
+import java.util.stream.Stream;
 
 public class SignFileArgument extends AbstractFileArgument {
 
@@ -23,13 +23,13 @@ public class SignFileArgument extends AbstractFileArgument {
     }
 
     @Suggestions("sign-file_suggestions")
-    public List<String> suggestSignFiles(CommandContext<SniperCommander> commandContext, String input) {
+    public Stream<String> suggestSignFiles(CommandContext<SniperCommander> commandContext, String input) {
         return super.suggestFiles(commandContext, input);
     }
 
     @Parser(name = "sign-file_parser", suggestions = "sign-file_suggestions")
-    public File parseSignFile(CommandContext<SniperCommander> commandContext, Queue<String> inputQueue) {
-        return super.parseFile(commandContext, inputQueue);
+    public File parseSignFile(CommandContext<SniperCommander> commandContext, CommandInput commandInput) {
+        return super.parseFile(commandContext, commandInput);
     }
 
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/argument/StencilFileArgument.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/argument/StencilFileArgument.java
@@ -1,14 +1,14 @@
 package com.thevoxelbox.voxelsniper.command.argument;
 
-import cloud.commandframework.annotations.parsers.Parser;
-import cloud.commandframework.annotations.suggestions.Suggestions;
-import cloud.commandframework.context.CommandContext;
+import org.incendo.cloud.annotations.parser.Parser;
+import org.incendo.cloud.annotations.suggestion.Suggestions;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.context.CommandInput;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.sniper.SniperCommander;
 
 import java.io.File;
-import java.util.List;
-import java.util.Queue;
+import java.util.stream.Stream;
 
 public class StencilFileArgument extends AbstractFileArgument {
 
@@ -23,13 +23,13 @@ public class StencilFileArgument extends AbstractFileArgument {
     }
 
     @Suggestions("stencil-file_suggestions")
-    public List<String> suggestStencilFiles(CommandContext<SniperCommander> commandContext, String input) {
+    public Stream<String> suggestStencilFiles(CommandContext<SniperCommander> commandContext, String input) {
         return super.suggestFiles(commandContext, input);
     }
 
     @Parser(name = "stencil-file_parser", suggestions = "stencil-file_suggestions")
-    public File parseStencilFile(CommandContext<SniperCommander> commandContext, Queue<String> inputQueue) {
-        return super.parseFile(commandContext, inputQueue);
+    public File parseStencilFile(CommandContext<SniperCommander> commandContext, CommandInput commandInput) {
+        return super.parseFile(commandContext, commandInput);
     }
 
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/argument/StencilListFileArgument.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/argument/StencilListFileArgument.java
@@ -1,14 +1,14 @@
 package com.thevoxelbox.voxelsniper.command.argument;
 
-import cloud.commandframework.annotations.parsers.Parser;
-import cloud.commandframework.annotations.suggestions.Suggestions;
-import cloud.commandframework.context.CommandContext;
+import org.incendo.cloud.annotations.parser.Parser;
+import org.incendo.cloud.annotations.suggestion.Suggestions;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.context.CommandInput;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.sniper.SniperCommander;
 
 import java.io.File;
-import java.util.List;
-import java.util.Queue;
+import java.util.stream.Stream;
 
 public class StencilListFileArgument extends AbstractFileArgument {
 
@@ -23,13 +23,13 @@ public class StencilListFileArgument extends AbstractFileArgument {
     }
 
     @Suggestions("stencil-list-file_suggestions")
-    public List<String> suggestStencilListFiles(CommandContext<SniperCommander> commandContext, String input) {
+    public Stream<String> suggestStencilListFiles(CommandContext<SniperCommander> commandContext, String input) {
         return super.suggestFiles(commandContext, input);
     }
 
     @Parser(name = "stencil-list-file_parser", suggestions = "stencil-list-file_suggestions")
-    public File parseStencilListFile(CommandContext<SniperCommander> commandContext, Queue<String> inputQueue) {
-        return super.parseFile(commandContext, inputQueue);
+    public File parseStencilListFile(CommandContext<SniperCommander> commandContext, CommandInput commandInput) {
+        return super.parseFile(commandContext, commandInput);
     }
 
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/argument/ToolkitArgument.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/argument/ToolkitArgument.java
@@ -1,17 +1,16 @@
 package com.thevoxelbox.voxelsniper.command.argument;
 
-import cloud.commandframework.annotations.parsers.Parser;
-import cloud.commandframework.annotations.suggestions.Suggestions;
-import cloud.commandframework.context.CommandContext;
-import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
+import org.incendo.cloud.annotations.parser.Parser;
+import org.incendo.cloud.annotations.suggestion.Suggestions;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.context.CommandInput;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.command.VoxelCommandElement;
 import com.thevoxelbox.voxelsniper.sniper.Sniper;
 import com.thevoxelbox.voxelsniper.sniper.toolkit.Toolkit;
 
-import java.util.List;
-import java.util.Queue;
+import java.util.stream.Stream;
 
 public class ToolkitArgument implements VoxelCommandElement {
 
@@ -28,22 +27,17 @@ public class ToolkitArgument implements VoxelCommandElement {
     }
 
     @Suggestions("toolkit_suggestions")
-    public List<String> suggestToolkits(CommandContext<Sniper> commandContext, String input) {
-        Sniper sniper = commandContext.getSender();
+    public Stream<String> suggestToolkits(CommandContext<Sniper> commandContext, String input) {
+        Sniper sniper = commandContext.sender();
         return sniper.getToolkits().stream()
                 .filter(toolkit -> !toolkit.isDefault())
-                .map(Toolkit::getToolkitName)
-                .toList();
+                .map(Toolkit::getToolkitName);
     }
 
     @Parser(suggestions = "toolkit_suggestions")
-    public Toolkit parseToolkit(CommandContext<Sniper> commandContext, Queue<String> inputQueue) {
-        String input = inputQueue.peek();
-        if (input == null) {
-            throw new NoInputProvidedException(ToolkitArgument.class, commandContext);
-        }
-
-        Sniper sniper = commandContext.getSender();
+    public Toolkit parseToolkit(CommandContext<Sniper> commandContext, CommandInput commandInput) {
+        String input = commandInput.readString();
+        Sniper sniper = commandContext.sender();
         Toolkit toolkit = sniper.getToolkit(input);
         if (toolkit == null) {
             throw new VoxelCommandElementParseException(input, Caption.of(
@@ -52,7 +46,6 @@ public class ToolkitArgument implements VoxelCommandElement {
             ));
         }
 
-        inputQueue.remove();
         return toolkit;
     }
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/BrushExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/BrushExecutor.java
@@ -1,10 +1,9 @@
 package com.thevoxelbox.voxelsniper.command.executor;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandDescription;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Range;
+import org.incendo.cloud.annotations.CommandDescription;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Range;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.brush.property.BrushProperties;
@@ -19,9 +18,9 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "brush|b")
+@Command(value = "brush|b")
 @CommandDescription("Brush executor.")
-@CommandPermission("voxelsniper.sniper")
+@Permission("voxelsniper.sniper")
 public class BrushExecutor implements VoxelCommandElement {
 
     private final VoxelSniperPlugin plugin;
@@ -32,7 +31,7 @@ public class BrushExecutor implements VoxelCommandElement {
         this.config = this.plugin.getVoxelSniperConfig();
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onBrush(
             final @NotNull Sniper sniper,
             final @NotNull Toolkit toolkit
@@ -49,11 +48,11 @@ public class BrushExecutor implements VoxelCommandElement {
         sniper.sendInfo(true);
     }
 
-    @CommandMethod("<size>")
+    @Command("<size>")
     public void onBrushSize(
             final @NotNull Sniper sniper,
             final @NotNull Toolkit toolkit,
-            final @Argument("size") @Range(min = "0", max = "500") int size
+            final @Range(min = "0", max = "500") int size
     ) {
         ToolkitProperties toolkitProperties = toolkit.getProperties();
         Player player = sniper.getPlayer();

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/BrushToolkitExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/BrushToolkitExecutor.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.command.executor;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandDescription;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.CommandDescription;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.world.item.ItemType;
@@ -18,9 +18,9 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.jetbrains.annotations.NotNull;
 
-@CommandMethod(value = "brush_toolkit|brushtoolkit|btool")
+@Command(value = "brush_toolkit|brushtoolkit|btool")
 @CommandDescription("Brush toolkit.")
-@CommandPermission("voxelsniper.sniper")
+@Permission("voxelsniper.sniper")
 public class BrushToolkitExecutor implements VoxelCommandElement {
 
     private final VoxelSniperPlugin plugin;
@@ -29,10 +29,10 @@ public class BrushToolkitExecutor implements VoxelCommandElement {
         this.plugin = plugin;
     }
 
-    @CommandMethod("assign <action> <toolkit-name>")
+    @Command("assign <action> <toolkit-name>")
     public void onBrushToolkitAssign(
             final @NotNull Sniper sniper,
-            final @NotNull @Argument("action") ToolAction action,
+            final @NotNull ToolAction action,
             final @NotNull @Argument("toolkit-name") String name
     ) {
         Player player = sniper.getPlayer();
@@ -60,10 +60,10 @@ public class BrushToolkitExecutor implements VoxelCommandElement {
         ));
     }
 
-    @CommandMethod("remove <toolkit>")
+    @Command("remove <toolkit>")
     public void onBrushToolkitRemove(
             final @NotNull Sniper sniper,
-            final @NotNull @Argument("toolkit") Toolkit toolkit
+            final @NotNull Toolkit toolkit
     ) {
         if (toolkit.isDefault()) {
             sniper.print(Caption.of("voxelsniper.command.toolkit.default-tool"));
@@ -74,7 +74,7 @@ public class BrushToolkitExecutor implements VoxelCommandElement {
         sniper.print(Caption.of("voxelsniper.command.toolkit.removed", toolkit.getToolkitName()));
     }
 
-    @CommandMethod("remove")
+    @Command("remove")
     public void onBrushToolkitRemove(
             final @NotNull Sniper sniper
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/DefaultExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/DefaultExecutor.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.command.executor;
 
-import cloud.commandframework.annotations.CommandDescription;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.CommandDescription;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.command.VoxelCommandElement;
@@ -12,9 +12,9 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.Toolkit;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "default|d")
+@Command(value = "default|d")
 @CommandDescription("VoxelSniper Default.")
-@CommandPermission("voxelsniper.sniper")
+@Permission("voxelsniper.sniper")
 public class DefaultExecutor implements VoxelCommandElement {
 
     private final VoxelSniperPlugin plugin;
@@ -23,7 +23,7 @@ public class DefaultExecutor implements VoxelCommandElement {
         this.plugin = plugin;
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onDefault(
             final @NotNull Sniper sniper,
             final @NotNull Toolkit toolkit

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/GotoExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/GotoExecutor.java
@@ -1,9 +1,8 @@
 package com.thevoxelbox.voxelsniper.command.executor;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandDescription;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.CommandDescription;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.command.VoxelCommandElement;
@@ -13,9 +12,9 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
-@CommandMethod(value = "goto")
+@Command(value = "goto")
 @CommandDescription("Warp to the specified coordinates.")
-@CommandPermission("voxelsniper.goto")
+@Permission("voxelsniper.goto")
 public class GotoExecutor implements VoxelCommandElement {
 
     private final VoxelSniperPlugin plugin;
@@ -24,11 +23,11 @@ public class GotoExecutor implements VoxelCommandElement {
         this.plugin = plugin;
     }
 
-    @CommandMethod("<x> <z>")
+    @Command("<x> <z>")
     public void onGoto(
             final @NotNull Sniper sniper,
-            final @Argument("x") int x,
-            final @Argument("z") int z
+            final int x,
+            final int z
     ) {
         Player player = sniper.getPlayer();
 

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/PaintExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/PaintExecutor.java
@@ -1,9 +1,8 @@
 package com.thevoxelbox.voxelsniper.command.executor;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandDescription;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.CommandDescription;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.command.VoxelCommandElement;
 import com.thevoxelbox.voxelsniper.sniper.Sniper;
@@ -13,9 +12,9 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-@CommandMethod(value = "paint")
+@Command(value = "paint")
 @CommandDescription("Change the selected painting to another painting.")
-@CommandPermission("voxelsniper.sniper")
+@Permission("voxelsniper.sniper")
 public class PaintExecutor implements VoxelCommandElement {
 
     private final VoxelSniperPlugin plugin;
@@ -24,7 +23,7 @@ public class PaintExecutor implements VoxelCommandElement {
         this.plugin = plugin;
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onPaint(
             final @NotNull Sniper sniper
     ) {
@@ -32,7 +31,7 @@ public class PaintExecutor implements VoxelCommandElement {
         ArtHelper.paintAuto(player, false);
     }
 
-    @CommandMethod("back")
+    @Command("back")
     public void onPaintBack(
             final @NotNull Sniper sniper
     ) {
@@ -40,10 +39,10 @@ public class PaintExecutor implements VoxelCommandElement {
         ArtHelper.paintAuto(player, true);
     }
 
-    @CommandMethod("<art>")
+    @Command("<art>")
     public void onPaintArt(
             final @NotNull Sniper sniper,
-            final @Nullable @Argument("art") Art art
+            final @Nullable Art art
     ) {
         Player player = sniper.getPlayer();
         ArtHelper.paint(player, art);

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/PerformerExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/PerformerExecutor.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.command.executor;
 
-import cloud.commandframework.annotations.CommandDescription;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.CommandDescription;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.brush.Brush;
@@ -14,9 +14,9 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.Toolkit;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p")
+@Command(value = "performer|perf|p")
 @CommandDescription("Performer executor.")
-@CommandPermission("voxelsniper.sniper")
+@Permission("voxelsniper.sniper")
 public class PerformerExecutor implements VoxelCommandElement {
 
     private final VoxelSniperPlugin plugin;
@@ -25,7 +25,7 @@ public class PerformerExecutor implements VoxelCommandElement {
         this.plugin = plugin;
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull Sniper sniper,
             final @NotNull Toolkit toolkit

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelCenterExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelCenterExecutor.java
@@ -1,9 +1,8 @@
 package com.thevoxelbox.voxelsniper.command.executor;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandDescription;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.CommandDescription;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.command.VoxelCommandElement;
 import com.thevoxelbox.voxelsniper.command.argument.annotation.RequireToolkit;
@@ -15,9 +14,9 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "voxel_center|voxelcenter|vc")
+@Command(value = "voxel_center|voxelcenter|vc")
 @CommandDescription("VoxelCenter & VoxelCentroid input.")
-@CommandPermission("voxelsniper.sniper")
+@Permission("voxelsniper.sniper")
 public class VoxelCenterExecutor implements VoxelCommandElement {
 
     private final VoxelSniperPlugin plugin;
@@ -26,11 +25,11 @@ public class VoxelCenterExecutor implements VoxelCommandElement {
         this.plugin = plugin;
     }
 
-    @CommandMethod("<center>")
+    @Command("<center>")
     public void onVoxelCenter(
             final @NotNull Sniper sniper,
             final @NotNull Toolkit toolkit,
-            final @Argument("center") int center
+            final int center
     ) {
         Player player = sniper.getPlayer();
         ToolkitProperties toolkitProperties = toolkit.getProperties();

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelChunkExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelChunkExecutor.java
@@ -1,8 +1,8 @@
 package com.thevoxelbox.voxelsniper.command.executor;
 
-import cloud.commandframework.annotations.CommandDescription;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.CommandDescription;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.command.VoxelCommandElement;
@@ -12,9 +12,9 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
-@CommandMethod(value = "voxel_chunk|voxelchunk|vchunk")
+@Command(value = "voxel_chunk|voxelchunk|vchunk")
 @CommandDescription("Update the chunk you are standing in.")
-@CommandPermission("voxelsniper.sniper")
+@Permission("voxelsniper.sniper")
 public class VoxelChunkExecutor implements VoxelCommandElement {
 
     private final VoxelSniperPlugin plugin;
@@ -23,7 +23,7 @@ public class VoxelChunkExecutor implements VoxelCommandElement {
         this.plugin = plugin;
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onVoxelChunk(
             final @NotNull Sniper sniper
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelExecutor.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.command.executor;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandDescription;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.CommandDescription;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -24,9 +24,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @RequireToolkit
-@CommandMethod(value = "voxel|v|voxel_ink|voxelink|vi")
+@Command(value = "voxel|v|voxel_ink|voxelink|vi")
 @CommandDescription("Voxel input.")
-@CommandPermission("voxelsniper.sniper")
+@Permission("voxelsniper.sniper")
 public class VoxelExecutor implements VoxelCommandElement {
 
     private final VoxelSniperPlugin plugin;
@@ -37,7 +37,7 @@ public class VoxelExecutor implements VoxelCommandElement {
         this.config = plugin.getVoxelSniperConfig();
     }
 
-    @CommandMethod("[pattern]")
+    @Command("[pattern]")
     public void onVoxel(
             final @NotNull Sniper sniper,
             final @NotNull Toolkit toolkit,

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelHeightExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelHeightExecutor.java
@@ -1,9 +1,8 @@
 package com.thevoxelbox.voxelsniper.command.executor;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandDescription;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.CommandDescription;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.thevoxelbox.voxelsniper.VoxelSniperPlugin;
 import com.thevoxelbox.voxelsniper.command.VoxelCommandElement;
 import com.thevoxelbox.voxelsniper.command.argument.annotation.RequireToolkit;
@@ -15,9 +14,9 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "voxel_height|voxelheight|vh")
+@Command(value = "voxel_height|voxelheight|vh")
 @CommandDescription("VoxelHeight input.")
-@CommandPermission("voxelsniper.sniper")
+@Permission("voxelsniper.sniper")
 public class VoxelHeightExecutor implements VoxelCommandElement {
 
     private final VoxelSniperPlugin plugin;
@@ -26,11 +25,11 @@ public class VoxelHeightExecutor implements VoxelCommandElement {
         this.plugin = plugin;
     }
 
-    @CommandMethod("<height>")
+    @Command("<height>")
     public void onVoxelHeight(
             final @NotNull Sniper sniper,
             final @NotNull Toolkit toolkit,
-            final @Argument("height") int height
+            final int height
     ) {
         Player player = sniper.getPlayer();
         ToolkitProperties toolkitProperties = toolkit.getProperties();

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelListExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelListExecutor.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.command.executor;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandDescription;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.CommandDescription;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -23,9 +23,9 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 
 @RequireToolkit
-@CommandMethod(value = "voxel_list|voxellist|vl")
+@Command(value = "voxel_list|voxellist|vl")
 @CommandDescription("Voxel block exclusions list.")
-@CommandPermission("voxelsniper.sniper")
+@Permission("voxelsniper.sniper")
 public class VoxelListExecutor implements VoxelCommandElement {
 
     private final VoxelSniperPlugin plugin;
@@ -34,7 +34,7 @@ public class VoxelListExecutor implements VoxelCommandElement {
         this.plugin = plugin;
     }
 
-    @CommandMethod("")
+    @Command("")
     public void onVoxelList(
             final @NotNull Sniper sniper,
             final @NotNull Toolkit toolkit
@@ -58,7 +58,7 @@ public class VoxelListExecutor implements VoxelCommandElement {
         messenger.sendVoxelListMessage(voxelList);
     }
 
-    @CommandMethod("clear")
+    @Command("clear")
     public void onVoxelListClear(
             final @NotNull Sniper sniper,
             final @NotNull Toolkit toolkit
@@ -72,7 +72,7 @@ public class VoxelListExecutor implements VoxelCommandElement {
         messenger.sendVoxelListMessage(voxelList);
     }
 
-    @CommandMethod("<blocks>")
+    @Command("<blocks>")
     public void onVoxelListBlocks(
             final @NotNull Sniper sniper,
             final @NotNull Toolkit toolkit,

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelReplaceExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelReplaceExecutor.java
@@ -1,9 +1,9 @@
 package com.thevoxelbox.voxelsniper.command.executor;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandDescription;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.CommandDescription;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -24,9 +24,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @RequireToolkit
-@CommandMethod(value = "voxel_replace|voxelreplace|vr|voxel_ink_replace|voxelinkreplace|vir")
+@Command(value = "voxel_replace|voxelreplace|vr|voxel_ink_replace|voxelinkreplace|vir")
 @CommandDescription("VoxelReplace input.")
-@CommandPermission("voxelsniper.sniper")
+@Permission("voxelsniper.sniper")
 public class VoxelReplaceExecutor implements VoxelCommandElement {
 
     private final VoxelSniperPlugin plugin;
@@ -37,7 +37,7 @@ public class VoxelReplaceExecutor implements VoxelCommandElement {
         this.config = plugin.getVoxelSniperConfig();
     }
 
-    @CommandMethod("[block]")
+    @Command("[block]")
     public void onVoxelReplace(
             final @NotNull Sniper sniper,
             final @NotNull Toolkit toolkit,

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelSniperExecutor.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/executor/VoxelSniperExecutor.java
@@ -1,10 +1,9 @@
 package com.thevoxelbox.voxelsniper.command.executor;
 
-import cloud.commandframework.annotations.Argument;
-import cloud.commandframework.annotations.CommandDescription;
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
-import cloud.commandframework.annotations.specifier.Range;
+import org.incendo.cloud.annotations.CommandDescription;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotation.specifier.Range;
 import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.intellectualsites.paster.IncendoPaster;
@@ -29,9 +28,9 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
-@CommandMethod("voxel_sniper|voxelsniper|vs|favs|fastasyncvoxelsniper")
+@Command("voxel_sniper|voxelsniper|vs|favs|fastasyncvoxelsniper")
 @CommandDescription("FastAsyncVoxelSniper Settings.")
-@CommandPermission("voxelsniper.sniper")
+@Permission("voxelsniper.sniper")
 public class VoxelSniperExecutor implements VoxelCommandElement {
 
     private final VoxelSniperPlugin plugin;
@@ -40,7 +39,7 @@ public class VoxelSniperExecutor implements VoxelCommandElement {
         this.plugin = plugin;
     }
 
-    @CommandMethod(value = "")
+    @Command(value = "")
     public void onVoxelSniper(
             final @NotNull Sniper sniper
     ) {
@@ -48,7 +47,7 @@ public class VoxelSniperExecutor implements VoxelCommandElement {
         sniper.sendInfo(false);
     }
 
-    @CommandMethod("brushes")
+    @Command("brushes")
     public void onVoxelSniperBrushes(
             final @NotNull SniperCommander commander
     ) {
@@ -65,7 +64,7 @@ public class VoxelSniperExecutor implements VoxelCommandElement {
         ));
     }
 
-    @CommandMethod("brusheslong")
+    @Command("brusheslong")
     public void onVoxelSniperBrusheslong(
             final @NotNull SniperCommander commander
     ) {
@@ -83,11 +82,11 @@ public class VoxelSniperExecutor implements VoxelCommandElement {
     }
 
     @RequireToolkit
-    @CommandMethod(value = "range [range]")
+    @Command(value = "range [range]")
     public void onVoxelSniperRange(
             final @NotNull Sniper sniper,
             final @NotNull Toolkit toolkit,
-            final @Nullable @Argument("range") @Range(min = "1") Integer range
+            final @Nullable  @Range(min = "1") Integer range
     ) {
         ToolkitProperties toolkitProperties = toolkit.getProperties();
         toolkitProperties.setBlockTracerRange(range);
@@ -98,7 +97,7 @@ public class VoxelSniperExecutor implements VoxelCommandElement {
         ));
     }
 
-    @CommandMethod("perf|performer")
+    @Command("perf|performer")
     public void onVoxelSniperPerformer(
             final @NotNull SniperCommander commander
     ) {
@@ -116,7 +115,7 @@ public class VoxelSniperExecutor implements VoxelCommandElement {
         ));
     }
 
-    @CommandMethod("perflong|performerlong")
+    @Command("perflong|performerlong")
     public void onVoxelSniperPerformerlong(
             final @NotNull SniperCommander commander
     ) {
@@ -134,7 +133,7 @@ public class VoxelSniperExecutor implements VoxelCommandElement {
         ));
     }
 
-    @CommandMethod(value = "enable")
+    @Command(value = "enable")
     public void onVoxelSniperEnable(
             final @NotNull Sniper sniper
     ) {
@@ -145,7 +144,7 @@ public class VoxelSniperExecutor implements VoxelCommandElement {
         ));
     }
 
-    @CommandMethod(value = "disable")
+    @Command(value = "disable")
     public void onVoxelSniperDisable(
             final @NotNull Sniper sniper
     ) {
@@ -156,7 +155,7 @@ public class VoxelSniperExecutor implements VoxelCommandElement {
         ));
     }
 
-    @CommandMethod(value = "toggle")
+    @Command(value = "toggle")
     public void onVoxelSniperToggle(
             final @NotNull Sniper sniper
     ) {
@@ -168,7 +167,7 @@ public class VoxelSniperExecutor implements VoxelCommandElement {
     }
 
     @SuppressWarnings("deprecation") // Paper deprecation
-    @CommandMethod("info")
+    @Command("info")
     public void onVoxelSniperInfo(
             final @NotNull SniperCommander commander
     ) {
@@ -180,8 +179,8 @@ public class VoxelSniperExecutor implements VoxelCommandElement {
         ));
     }
 
-    @CommandMethod("reload")
-    @CommandPermission("voxelsniper.admin")
+    @Command("reload")
+    @Permission("voxelsniper.admin")
     public void onVoxelSniperReload(
             final @NotNull SniperCommander commander
     ) {
@@ -189,8 +188,8 @@ public class VoxelSniperExecutor implements VoxelCommandElement {
         commander.print(Caption.of("voxelsniper.command.voxel-sniper.config-reload"));
     }
 
-    @CommandMethod("debugpaste")
-    @CommandPermission("voxelsniper.admin")
+    @Command("debugpaste")
+    @Permission("voxelsniper.admin")
     public void onVoxelSniperDebugpaste(
             final @NotNull SniperCommander commander
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/ComboComboNoPhysicsPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/ComboComboNoPhysicsPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.combo;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -12,14 +12,14 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p combo-combo-nophys|ccp")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p combo-combo-nophys|ccp")
+@Permission("voxelsniper.sniper")
 public class ComboComboNoPhysicsPerformer extends AbstractPerformer {
 
     private Pattern pattern;
     private BlockState replaceBlockData;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/ComboComboPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/ComboComboPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.combo;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -12,14 +12,14 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p combo-combo|cc")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p combo-combo|cc")
+@Permission("voxelsniper.sniper")
 public class ComboComboPerformer extends AbstractPerformer {
 
     private Pattern pattern;
     private BlockState replaceBlockData;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/ComboInkNoPhysicsPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/ComboInkNoPhysicsPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.combo;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -12,14 +12,14 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p combo-ink-nophys|cip")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p combo-ink-nophys|cip")
+@Permission("voxelsniper.sniper")
 public class ComboInkNoPhysicsPerformer extends AbstractPerformer {
 
     private Pattern pattern;
     private BlockState replaceBlockData;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/ComboInkPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/ComboInkPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.combo;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -12,14 +12,14 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p combo-ink|ci")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p combo-ink|ci")
+@Permission("voxelsniper.sniper")
 public class ComboInkPerformer extends AbstractPerformer {
 
     private Pattern pattern;
     private BlockState replaceBlockData;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/ComboMaterialNoPhysicsPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/ComboMaterialNoPhysicsPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.combo;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -12,14 +12,14 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p combo-mat-nophys|cmp")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p combo-mat-nophys|cmp")
+@Permission("voxelsniper.sniper")
 public class ComboMaterialNoPhysicsPerformer extends AbstractPerformer {
 
     private Pattern pattern;
     private BlockState replaceBlockData;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/ComboMaterialPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/ComboMaterialPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.combo;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -12,14 +12,14 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p combo-mat|cm")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p combo-mat|cm")
+@Permission("voxelsniper.sniper")
 public class ComboMaterialPerformer extends AbstractPerformer {
 
     private Pattern pattern;
     private BlockState replaceBlockData;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/ComboNoPhysicsPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/ComboNoPhysicsPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.combo;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -12,13 +12,13 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p combo-nophys|cp")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p combo-nophys|cp")
+@Permission("voxelsniper.sniper")
 public class ComboNoPhysicsPerformer extends AbstractPerformer {
 
     private Pattern pattern;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/ComboPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/ComboPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.combo;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -12,13 +12,13 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p combo|c")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p combo|c")
+@Permission("voxelsniper.sniper")
 public class ComboPerformer extends AbstractPerformer {
 
     private Pattern pattern;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/ExcludeComboPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/ExcludeComboPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.combo;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -14,14 +14,14 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p exclude-combo|xc")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p exclude-combo|xc")
+@Permission("voxelsniper.sniper")
 public class ExcludeComboPerformer extends AbstractPerformer {
 
     private Collection<BlockState> excludeList;
     private Pattern pattern;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/IncludeComboPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/combo/IncludeComboPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.combo;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -14,14 +14,14 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p include-combo|nc")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p include-combo|nc")
+@Permission("voxelsniper.sniper")
 public class IncludeComboPerformer extends AbstractPerformer {
 
     private Collection<BlockState> includeList;
     private Pattern pattern;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/ExcludeInkPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/ExcludeInkPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.ink;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -14,14 +14,14 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p exclude-ink|xi")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p exclude-ink|xi")
+@Permission("voxelsniper.sniper")
 public class ExcludeInkPerformer extends AbstractPerformer {
 
     private Collection<BlockState> excludeList;
     private Pattern pattern;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/IncludeInkPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/IncludeInkPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.ink;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -14,14 +14,14 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p include-ink|ni")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p include-ink|ni")
+@Permission("voxelsniper.sniper")
 public class IncludeInkPerformer extends AbstractPerformer {
 
     private Collection<BlockState> includeList;
     private Pattern pattern;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/InkComboNoPhysicsPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/InkComboNoPhysicsPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.ink;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -12,14 +12,14 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p ink-combo-nophys|icp")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p ink-combo-nophys|icp")
+@Permission("voxelsniper.sniper")
 public class InkComboNoPhysicsPerformer extends AbstractPerformer {
 
     private Pattern pattern;
     private BlockState replaceBlockData;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/InkComboPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/InkComboPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.ink;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -12,14 +12,14 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p ink-combo|ic")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p ink-combo|ic")
+@Permission("voxelsniper.sniper")
 public class InkComboPerformer extends AbstractPerformer {
 
     private Pattern pattern;
     private BlockState replaceBlockData;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/InkInkNoPhysicsPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/InkInkNoPhysicsPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.ink;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -12,14 +12,14 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p ink-ink-nophys|iip")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p ink-ink-nophys|iip")
+@Permission("voxelsniper.sniper")
 public class InkInkNoPhysicsPerformer extends AbstractPerformer {
 
     private Pattern pattern;
     private BlockState replaceBlockData;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/InkInkPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/InkInkPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.ink;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -12,14 +12,14 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p ink-ink|ii")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p ink-ink|ii")
+@Permission("voxelsniper.sniper")
 public class InkInkPerformer extends AbstractPerformer {
 
     private Pattern pattern;
     private BlockState replaceBlockData;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/InkMaterialNoPhysicsPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/InkMaterialNoPhysicsPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.ink;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -13,14 +13,14 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p ink-mat-nophys|imp")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p ink-mat-nophys|imp")
+@Permission("voxelsniper.sniper")
 public class InkMaterialNoPhysicsPerformer extends AbstractPerformer {
 
     private Pattern pattern;
     private BlockType replaceType;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/InkMaterialPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/InkMaterialPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.ink;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -13,14 +13,14 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p ink-mat|im")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p ink-mat|im")
+@Permission("voxelsniper.sniper")
 public class InkMaterialPerformer extends AbstractPerformer {
 
     private Pattern pattern;
     private BlockType replaceType;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/InkNoPhysicsPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/InkNoPhysicsPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.ink;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -12,13 +12,13 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p ink-nophys|ip")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p ink-nophys|ip")
+@Permission("voxelsniper.sniper")
 public class InkNoPhysicsPerformer extends AbstractPerformer {
 
     private Pattern pattern;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/InkPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/ink/InkPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.ink;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -12,13 +12,13 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p ink|i")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p ink|i")
+@Permission("voxelsniper.sniper")
 public class InkPerformer extends AbstractPerformer {
 
     private Pattern pattern;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/ExcludeMaterialPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/ExcludeMaterialPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.material;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -14,14 +14,14 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p exclude-mat|xm")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p exclude-mat|xm")
+@Permission("voxelsniper.sniper")
 public class ExcludeMaterialPerformer extends AbstractPerformer {
 
     private Collection<BlockState> excludeList;
     private Pattern pattern;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/IncludeMaterialPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/IncludeMaterialPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.material;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -14,14 +14,14 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p include-mat|nm")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p include-mat|nm")
+@Permission("voxelsniper.sniper")
 public class IncludeMaterialPerformer extends AbstractPerformer {
 
     private Collection<BlockState> includeList;
     private Pattern pattern;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/MaterialComboNoPhysicsPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/MaterialComboNoPhysicsPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.material;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -12,14 +12,14 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p mat-combo-nophys|mcp")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p mat-combo-nophys|mcp")
+@Permission("voxelsniper.sniper")
 public class MaterialComboNoPhysicsPerformer extends AbstractPerformer {
 
     private Pattern pattern;
     private BlockState replaceBlockData;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/MaterialComboPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/MaterialComboPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.material;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -12,14 +12,14 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p mat-combo|mc")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p mat-combo|mc")
+@Permission("voxelsniper.sniper")
 public class MaterialComboPerformer extends AbstractPerformer {
 
     private Pattern pattern;
     private BlockState replaceBlockData;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/MaterialInkNoPhysicsPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/MaterialInkNoPhysicsPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.material;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -12,14 +12,14 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p mat-ink-nophys|mip")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p mat-ink-nophys|mip")
+@Permission("voxelsniper.sniper")
 public class MaterialInkNoPhysicsPerformer extends AbstractPerformer {
 
     private Pattern pattern;
     private BlockState replaceBlockData;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/MaterialInkPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/MaterialInkPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.material;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -12,14 +12,14 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p mat-ink|mi")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p mat-ink|mi")
+@Permission("voxelsniper.sniper")
 public class MaterialInkPerformer extends AbstractPerformer {
 
     private Pattern pattern;
     private BlockState replaceBlockData;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/MaterialMaterialNoPhysicsPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/MaterialMaterialNoPhysicsPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.material;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -13,14 +13,14 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p mat-mat-nophys|mmp")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p mat-mat-nophys|mmp")
+@Permission("voxelsniper.sniper")
 public class MaterialMaterialNoPhysicsPerformer extends AbstractPerformer {
 
     private Pattern pattern;
     private BlockType replaceType;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/MaterialMaterialPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/MaterialMaterialPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.material;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -13,14 +13,14 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p mat-mat|mm")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p mat-mat|mm")
+@Permission("voxelsniper.sniper")
 public class MaterialMaterialPerformer extends AbstractPerformer {
 
     private Pattern pattern;
     private BlockType replaceType;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/MaterialNoPhysicsPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/MaterialNoPhysicsPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.material;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BaseBlock;
@@ -13,13 +13,13 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p mat-nophys|mp")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p mat-nophys|mp")
+@Permission("voxelsniper.sniper")
 public class MaterialNoPhysicsPerformer extends AbstractPerformer {
 
     private Pattern pattern;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/MaterialPerformer.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/performer/type/material/MaterialPerformer.java
@@ -1,7 +1,7 @@
 package com.thevoxelbox.voxelsniper.performer.type.material;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BaseBlock;
@@ -13,13 +13,13 @@ import com.thevoxelbox.voxelsniper.sniper.toolkit.ToolkitProperties;
 import org.jetbrains.annotations.NotNull;
 
 @RequireToolkit
-@CommandMethod(value = "performer|perf|p material|mat|m")
-@CommandPermission("voxelsniper.sniper")
+@Command(value = "performer|perf|p material|mat|m")
+@Permission("voxelsniper.sniper")
 public class MaterialPerformer extends AbstractPerformer {
 
     private Pattern pattern;
 
-    @CommandMethod("")
+    @Command("")
     public void onPerformer(
             final @NotNull PerformerSnipe snipe
     ) {


### PR DESCRIPTION
This is still a W.I.P. as Cloud v2 is nowhere near ready to be released. There are no up-to-date builds in the OSS repository, so this currently relies on the local Maven repository.

Changes:
- `@Argument` is not needed when the parameter name is the same as the argument name.
- The input queues have been replaced with `CommandInput`.
- Suggestions can return streams so we do not need to manually collect before returning.
- There is a new exception handling system that reduces the amount of casting and unwrapping we have to do.
- Meta keys no longer exist and have been replaced by `CloudKey`.

Do we want to use suggestions with tooltips? Can we convey meaningful information through the tooltips?