### PR TITLE
Fix 'Sniper not found' on login

### DIFF
--- a/src/main/java/com/thevoxelbox/voxelsniper/listener/PlayerQuitListener.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/listener/PlayerQuitListener.java
@@ -11,18 +11,17 @@ import org.bukkit.event.player.PlayerQuitEvent;
 public class PlayerQuitListener implements Listener<PlayerQuitEvent> {
 
     private final VoxelSniperPlugin plugin;
+    private final VoxelSniperConfig config;
 
     public PlayerQuitListener(VoxelSniperPlugin plugin) {
         this.plugin = plugin;
+        this.config = plugin.getVoxelSniperConfig();
     }
 
     @EventHandler
     @Override
     public void listen(final PlayerQuitEvent event) {
-        VoxelSniperConfig config = this.plugin.getVoxelSniperConfig();
-        if (!config.arePersistentSessionsEnabled()) {
-            unregisterSniper(event.getPlayer());
-        }
+        unregisterSniper(event.getPlayer());
     }
 
     private void unregisterSniper(Player player) {
@@ -31,7 +30,11 @@ public class PlayerQuitListener implements Listener<PlayerQuitEvent> {
         if (sniper == null) {
             return;
         }
-        sniperRegistry.unregister(sniper);
+
+        sniper.setPlayer(null);
+        if (!config.arePersistentSessionsEnabled()) {
+            sniperRegistry.unregister(sniper);
+        }
     }
 
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/sniper/Sniper.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/sniper/Sniper.java
@@ -76,13 +76,23 @@ public class Sniper implements SniperCommander {
     }
 
     public Player getPlayer() {
-        if (player == null || !player.isValid()) {
+        if (player == null) {
             player = Bukkit.getPlayer(this.uuid);
         }
         if (player == null) {
             throw new UnknownSniperPlayerException();
         }
         return player;
+    }
+
+    /**
+     * Set the player.
+     *
+     * @param player the player
+     * @since TODO
+     */
+    public void setPlayer(Player player) {
+        this.player = player;
     }
 
     @Override

--- a/src/main/java/com/thevoxelbox/voxelsniper/sniper/SniperRegistry.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/sniper/SniperRegistry.java
@@ -60,6 +60,8 @@ public class SniperRegistry {
         if (sniper == null) {
             sniper = new Sniper(player);
             register(sniper);
+        } else {
+            sniper.setPlayer(player);
         }
         return sniper;
     }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #326

## Description
<!-- Please describe what this pull request does. -->
- Do not rely on Bukkit ``Player#isValid`` method as it can return false for a logging in player under some _unknown_ circumstances.
- Provide the safe and existing player object to the Sniper when registering and fetch it only when null.
- Force the player instance to be null when leaving to avoid any potential overlap with the former player instance.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
